### PR TITLE
Relax the RE for Blender download

### DIFF
--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -25,7 +25,7 @@
 				<key>url</key>
 				<string>http://www.blender.org/download/</string>
 				<key>re_pattern</key>
-				<string>(http://.*/blender-[0-9\.]+[a-z]??-OSX_[0-9\.]+-%ARCH%.zip)</string>
+				<string>(http://.*/blender-[0-9\.]+[a-z]??-OSX_[0-9\.]+-.*?%ARCH%.zip)</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 			</dict>


### PR DESCRIPTION
Just a minor tweak since I noticed the Blender recipe fail today. Not sure if you're seeing the same thing, but if so here's a minor tweak I added to allow for the extra "-j2k-fix" that was added in the URL.
