### PR TITLE
new(?) feed URL for textexpander

### DIFF
--- a/SmileOnMyMac/TextExpander.download.recipe
+++ b/SmileOnMyMac/TextExpander.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>TextExpander</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://updateinfo.devmate.com/com.smileonmymac.textexpander/updates.xml</string>
+		<string>http://updates.smilesoftware.com/com.smileonmymac.textexpander.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>

--- a/SmileOnMyMac/TextExpander.download.recipe
+++ b/SmileOnMyMac/TextExpander.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>TextExpander</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://smilesoftware.com/appcast/TextExpander.xml</string>
+		<string>http://updateinfo.devmate.com/com.smileonmymac.textexpander/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>


### PR DESCRIPTION
They haven’t updated the info.plist SUFeedURL, but this is what Charles uncovered for me and ‘just works’ when substituted in for the previous URL