### PR TITLE
Updates and cleanups to recipes.

### DIFF
--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -3,18 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Blender. Set ARCH to either x86_64 or i386, if not defined the default is x86_64.</string>
+	<string>Downloads the latest Blender. The only supported architecture is (since v2.72) x86_64.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.Blender</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>Blender</string>
-		<key>ARCH</key>
-		<string>x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>0.4.2</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -25,7 +23,7 @@
 				<key>url</key>
 				<string>http://www.blender.org/download/</string>
 				<key>re_pattern</key>
-				<string>(http://.*/blender-[0-9\.]+[a-z]??-OSX_[0-9\.]+-.*?%ARCH%.zip)</string>
+				<string>(http://.*/blender-(?:[^"']*)-OSX_(?:[^"']+)-x86_64.zip)</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 			</dict>
@@ -62,9 +60,20 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Blender/blender.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/blender.app</string>
 				<key>requirement</key>
 				<string>identifier "org.blenderfoundation.blender" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "68UA947AUU"</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/blenderplayer.app</string>
+				<key>requirement</key>
+				<string>identifier "org.blenderfoundation.blenderplayer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "68UA947AUU"</string>
 			</dict>
 		</dict>
 	</array>

--- a/Blender/Blender.install.recipe
+++ b/Blender/Blender.install.recipe
@@ -10,7 +10,7 @@
 	<dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>0.4.2</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.pkg.Blender</string>
 	<key>Process</key>

--- a/Blender/Blender.munki.recipe
+++ b/Blender/Blender.munki.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Blender</string>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps</string>
+		<string>apps/%NAME%</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Graphics &amp; Rendering</string>
 		<key>pkginfo</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>0.4.2</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Blender</string>
 	<key>Process</key>
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications</string>
 				<key>pkgdirs</key>
 				<dict>
 					<key>Blender</key>
@@ -55,26 +55,26 @@
 			</dict>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>Copier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Blender/blender.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot/Blender/blender.app</string>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/%NAME%</string>
 				<key>overwrite</key>
 				<string>true</string>
 			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot/Blender/blender.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/%NAME%/blender.app/Contents/Info.plist</string>
 			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
 		</dict>
 		<dict>
 			<key>Processor</key>
@@ -90,18 +90,40 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/%NAME%/blender.app</string>
+					<string>/Applications/%NAME%/blenderplayer.app</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict/>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>DmgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_megabytes</key>
-				<string>300</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot/Blender</string>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>path_list</key>
@@ -110,19 +132,19 @@
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				</array>
 			</dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
 				<string>%dmg_path%</string>
+				<key>munkiimport_appname</key>
+				<string>%NAME%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
 		</dict>
 	</array>
 </dict>

--- a/Blender/Blender.pkg.recipe
+++ b/Blender/Blender.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Blender</string>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.4.2</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -41,7 +41,7 @@
 				<key>archive_path</key>
 				<string>%pathname%</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications</string>
+				<string>%pkgroot%/Applications/%NAME%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -52,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/Blender/Blender.app</string>
+				<string>%pkgroot%/Applications/Blender/blender.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
**Blender.download.recipe:**
* Fixed URLTextSearcher regex which stopped working with v2.76-rc#
  release on download page.
* Removed `%ARCH%` variable, and replaced with hard-coded
  `x86_64` as Blender only supports that architecture since ~2.72.
* Updated 'Description'.
* Fixup to `CodeSignatureVerifier` `input_path` for `blender.app`
* Added `CodeSignatureVerifier` for `blenderplayer.app`

**Blender.munki.recipe:**
* Changed `MUNKI_REPO_SUBDIR` to `apps/%NAME%` to help keep the
  repo tidier.
* ZIP file contents are now placed into `pkgroot/Applications/
  %NAME%`
* Added `MunkiInstallsItemsCreator` Processor to handle both
  *.app bundles.
* Updated `MunkiImporter` to copy out folder to `/Applications`

**Blender.pkg.recipe:**
* Minor pathname fixups

**All:**
* Where applicable, moved the `Processor` key and string to the
  top of their container `dict`s to allow easier scanning and
  reading of the recipe files.
* Updated MinimumVersion to 0.4.2 for consistency.
* Blender’s packaging and download site do not have a particularly
  clear means (at least for any reasonable scripting or recipe) to
  differentiate/identify 'stable' releases from 'release candidate'.
  *Additionally* the CFBundleVersion keys do *not* indicate "-rc#'
  status either. So, to AutoPkg and munki (and OS X), v2.76-rc3
  _is_ '2.76'. I suspect this could break Munki updates since
  if/when an actual v2.76 is released there is nothing to literally
  differentiate it. >:-/