### PR TITLE
Added dmg_megabytes key to DmgCreator step.

### DIFF
--- a/Blender/Blender.munki.recipe
+++ b/Blender/Blender.munki.recipe
@@ -119,6 +119,8 @@
 				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_megabytes</key>
+				<string>400</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
I was seeing `hdiutil: create failed - error -5431` messages. I added `dmg_megabytes` to the `DmgCreator` Processor in Blender.munki.recipe. This seems to fix, or at least alleviate, the issue.

_Note: The current size of blender.