### PR TITLE
Add USER_AGENT to LibreOffice.download

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -12,6 +12,8 @@
 		<string>LibreOffice</string>
 		<key>TYPE</key>
 		<string>mac-x86_64</string>
+		<key>USER_AGENT</key>
+        	<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -29,6 +31,14 @@
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+    			<key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>%USER_AGENT%</string>
+                </dict>
+            </dict>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -13,7 +13,7 @@
 		<key>TYPE</key>
 		<string>mac-x86_64</string>
 		<key>USER_AGENT</key>
-        	<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -33,12 +33,12 @@
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-    			<key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
-            </dict>
+				<key>request_headers</key>
+				<dict>
+					<key>user-agent</key>
+					<string>%USER_AGENT%</string>
+				</dict>
+			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
Had been getting this for days/weeks:

```
Processing LibreOffice.munki...
Couldn't download http://tdf.xfree.com.ar/libreoffice/stable/5.0.2/mac/x86_64/LibreOffice_5.0.2_MacOS_x86-64.dmg (HTTP Error 403: Forbidden)
Failed.
```

Figured someone else would notice and fix it, but nope.  Looks like urllib2's user-agent is being blocked, so we spoof a different one...