### PR TITLE
Fix Blender download zip now including an intermediate path

### DIFF
--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -56,11 +56,20 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>FileFinder</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/*</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/blender.app</string>
+				<string>%found_filename%/blender.app</string>
 				<key>requirement</key>
 				<string>identifier "org.blenderfoundation.blender" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "68UA947AUU"</string>
 			</dict>
@@ -71,7 +80,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/blenderplayer.app</string>
+				<string>%found_filename%/blenderplayer.app</string>
 				<key>requirement</key>
 				<string>identifier "org.blenderfoundation.blenderplayer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "68UA947AUU"</string>
 			</dict>

--- a/Blender/Blender.munki.recipe
+++ b/Blender/Blender.munki.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<string>%found_filename%</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/%NAME%</string>
 				<key>overwrite</key>

--- a/Blender/Blender.pkg.recipe
+++ b/Blender/Blender.pkg.recipe
@@ -28,18 +28,16 @@
 				<dict>
 					<key>Applications</key>
 					<string>0775</string>
-					<key>Applications/Blender</key>
-					<string>0775</string>
 				</dict>
 			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
+			<string>Copier</string>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
+				<key>source_path</key>
+				<string>%found_filename%</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/Applications/%NAME%</string>
 				<key>purge_destination</key>
@@ -83,11 +81,13 @@
 					<array>
 						<dict>
 							<key>path</key>
-							<string>Applications/%NAME%</string>
+							<string>Applications</string>
 							<key>user</key>
 							<string>root</string>
 							<key>group</key>
 							<string>admin</string>
+							<key>mode</key>
+							<string>0755</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Here I'm using FileFinder and globbing the top level of the zip archive.

The changes needed for the pkg recipe were a bit of a workaround - instead of creating both dirs in PkgCreator I skipped creating %NAME% and copied the dir we found in the parent recipe to become %NAME%. Finally we add a `mode` key to PkgCreator to fix the 700 permissions of that unarchived zip folder.

I found that trying to chown both /Applications and /Applications/%NAME% later in PkgCreator gave me odd permissions. I don't fully understand why starting the chown a level up seemed to give me the permissions I wanted.