### PR TITLE
Removing OS_RELEASE from input settings (R.munki)

### DIFF
--- a/R/R.munki.recipe
+++ b/R/R.munki.recipe
@@ -10,8 +10,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>R</string>
-		<key>OS_RELEASE</key>
-		<string>snowleopard</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/R</string>
 		<key>MUNKI_CATEGORY</key>


### PR DESCRIPTION
Removing OS_RELEASE from input settings to use the default one set in the download recipe.