### PR TITLE
Change URLDownloader to CURLDownloader to mitigate SSL errors

### DIFF
--- a/GitHub/Atom.download.recipe
+++ b/GitHub/Atom.download.recipe
@@ -17,7 +17,7 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLDownloader</string>
+			<string>CURLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>

--- a/GitHub/Atom.download.recipe
+++ b/GitHub/Atom.download.recipe
@@ -12,7 +12,7 @@
 		<string>Atom</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>0.5.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SmileOnMyMac/TextExpander.download.recipe
+++ b/SmileOnMyMac/TextExpander.download.recipe
@@ -28,7 +28,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>URLDownloader</string>
+			<string>CURLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SmileOnMyMac/TextExpander.download.recipe
+++ b/SmileOnMyMac/TextExpander.download.recipe
@@ -14,7 +14,7 @@
 		<string>http://updates.smilesoftware.com/com.smileonmymac.textexpander.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>0.5.1</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Running the existing download recipes for Atom and TextExpander on a 10.7.5 machine with python 2.7.1 I'm getting SSL errors like:

```
Processing Atom.munki...
URLDownloader
Couldn't download https://atom.io/download/mac (<urlopen error [Errno 1] _ssl.c:499: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>)
Failed.
Receipt written to /Users/admin/Library/AutoPkg/Cache/local.munki.Atom/receipts/Atom-receipt-20160114-103502.plist
The following recipes failed:
    Atom.munki
        Error in local.munki.Atom: Processor: URLDownloader: Error: Couldn't download https://atom.io/download/mac (<urlopen error [Errno 1] _ssl.c:499: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>)
Nothing downloaded, packaged or imported.
```

With autopkg .5.1 (https://github.com/autopkg/autopkg/releases/tag/v0.5.1) CURLDownloader was made available to mitigate SSL errors.  Changing URLDownloader to CURLDownloader on these two recieps allowed them to download successfully.

On a newer system running OS 10.11.2 with (system provided) python 2.7.10 both URLDownloader and CURLDownloader work as expected and download successfully.

Note, this change to CURLDownloader will require Autopkg .5.1+ which has been out since September 2015.