### PR TITLE
remove DMG creation step

### DIFF
--- a/ATLAS.ti/ATLAS.ti.munki.recipe
+++ b/ATLAS.ti/ATLAS.ti.munki.recipe
@@ -44,31 +44,14 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_megabytes</key>
-				<string>800</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
+			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
After checking out lastest update, we are getting the error:

```
The following recipes failed:
    ATLAS.ti.munki
        Error in local.munki.ATLAS.ti: Processor: DmgCreator: Error: creation of /Users/user/Library/AutoPkg/Cache/local.munki.ATLAS.ti/ATLAS.ti.dmg failed: hdiutil: create failed - No such file or directory
```

I've removed the DMG creation step (which is unnessary as shipped file is a DMG), and this seems to solve this issue.