### PR TITLE
Update URLs to be https instead of http

### DIFF
--- a/TeXstudio/TeXstudio.download.recipe
+++ b/TeXstudio/TeXstudio.download.recipe
@@ -23,9 +23,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://sourceforge.net/projects/texstudio/rss?limit=10</string>
+				<string>https://sourceforge.net/projects/texstudio/rss?limit=10</string>
 				<key>re_pattern</key>
-				<string>http://sourceforge.net/projects/texstudio/files/texstudio/TeXstudio%20(?P&lt;version&gt;[0-9\.]+)/texstudio</string>
+				<string>https://sourceforge.net/projects/texstudio/files/texstudio/TeXstudio%20(?P&lt;version&gt;[0-9\.]+)/texstudio</string>
 			</dict>
 		</dict>
 		<dict>
@@ -36,11 +36,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<!--    http://sourceforge.net/projects/texstudio/rss?path=/texstudio/TeXstudio%202.10.4 -->
-				<string>http://sourceforge.net/projects/texstudio/rss?path=/texstudio/TeXstudio%20%version%</string>
+				<!--    https://sourceforge.net/projects/texstudio/rss?path=/texstudio/TeXstudio%202.10.4 -->
+				<string>https://sourceforge.net/projects/texstudio/rss?path=/texstudio/TeXstudio%20%version%</string>
 				<key>re_pattern</key>
-				<!-- http://sourceforge.net/projects/texstudio/files/texstudio/TeXstudio%202.10.4/texstudio-2.10.4-osx-qt5.5.1.zip/download -->
-				<string>(?P&lt;url&gt;http://.*/TeXstudio%20%version%/texstudio[_\-]%version%[_\-]osx[_\-]qt[0-9\.]+\.zip/download)</string>
+				<!-- https://sourceforge.net/projects/texstudio/files/texstudio/TeXstudio%202.10.4/texstudio-2.10.4-osx-qt5.5.1.zip/download -->
+				<string>(?P&lt;url&gt;https://.*/TeXstudio%20%version%/texstudio[_\-]%version%[_\-]osx[_\-]qt[0-9\.]+\.zip/download)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
SourceForge changed the URLs from http to https.  This updates the TeXstudio.download.recipe file to reflect these changes.