### PR TITLE
Added required argument to Installer processor

### DIFF
--- a/TeamViewer/TeamViewer.install.recipe
+++ b/TeamViewer/TeamViewer.install.recipe
@@ -18,6 +18,12 @@
 		<dict>
 			<key>Processor</key>
 			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+			    <key>pkg_path</key>
+			    <string>%pathname%/Install TeamViewer.pkg</string>
+			</dict>
+
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
The required pkg_path key was missing causing the recipe to fail:

```
autopkg run -v TeamViewer.install
Processing TeamViewer.install...
Failed.
Receipt written to /tmp/receipts/TeamViewer-receipt-20160707-133507.plist
The following recipes failed:
    TeamViewer.install
        Installer requires missing argument pkg_path
Nothing downloaded, packaged or imported.
```
Added the `pkg_path` key and path to the pkg inside the downloaded dmg.