### PR TITLE
Updated Citrix Receiver Developer ID Certificate name

### DIFF
--- a/CitrixReceiver/CitrixReceiver.download.recipe
+++ b/CitrixReceiver/CitrixReceiver.download.recipe
@@ -50,7 +50,7 @@
 				<string>%pathname%/Install Citrix Receiver.pkg</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Citrix Systems, Inc.</string>
+					<string>Developer ID Installer: Citrix Systems, Inc. (KBVSJ83SS9)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Looks like Citrix changed their signing certificate. These changes resolve the issue.