### PR TITLE
Increased TeXStudio rss URL limit from 10 to 20

### DIFF
--- a/TeXstudio/TeXstudio.download.recipe
+++ b/TeXstudio/TeXstudio.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://sourceforge.net/projects/texstudio/rss?limit=10</string>
+				<string>https://sourceforge.net/projects/texstudio/rss?limit=20</string>
 				<key>re_pattern</key>
 				<string>https://sourceforge.net/projects/texstudio/files/texstudio/TeXstudio%20(?P&lt;version&gt;[0-9\.]+)/texstudio[_-][0-9\.]+[_-]osx[_-]qt[0-9\.]+\.zip</string>
 			</dict>


### PR DESCRIPTION
apparently https://sourceforge.net/projects/texstudio/rss?limit=10 is not enough right now to actually include the latest osx package