### PR TITLE
Add CHECK_FILESIZE_ONLY to Bibdesk.download

### DIFF
--- a/BibDesk/BibDesk.download.recipe
+++ b/BibDesk/BibDesk.download.recipe
@@ -31,6 +31,8 @@
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
+				<key>CHECK_FILESIZE_ONLY</key>
+				<true/>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Vendor appears to be using mirrors, leading to repeated downloads of Bibdesk.dmg. Added `CHECK_FILESIZE_ONLY` to mitigate this.