### PR TITLE
OpenOffice.download.recipe: RSS limit no longer enough to include English version

### DIFF
--- a/OpenOffice/OpenOffice.download.recipe
+++ b/OpenOffice/OpenOffice.download.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://sourceforge.net/projects/openofficeorg.mirror/rss?limit=600</string>
+				<string>https://sourceforge.net/projects/openofficeorg.mirror/rss?limit=700</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;https://sourceforge.net/projects/openofficeorg.mirror/files/(?P&lt;version&gt;[0-9\.]+)/binaries/%LANGUAGE%/(?P&lt;filename&gt;Apache_OpenOffice_[0-9\.]+_MacOS_x86-64_install_%LANGUAGE%\.dmg)/download)</string>
 			</dict>


### PR DESCRIPTION
The limit of 600 is not enough to include the current English version of the OpenOffice software. Expanding it to 700 allows the download recipe to work as expected.