### PR TITLE
Add PathDeleter to Atom.pkg.recipe

### DIFF
--- a/GitHub/Atom.pkg.recipe
+++ b/GitHub/Atom.pkg.recipe
@@ -91,6 +91,18 @@
 				</dict>
 			</dict>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%-pkg</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Add PathDeleter to clean up after creating the package.