### PR TITLE
Added filename argument to URLDownloader processor

### DIFF
--- a/OpenOffice/OpenOffice.download.recipe
+++ b/OpenOffice/OpenOffice.download.recipe
@@ -35,6 +35,8 @@
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
 				<key>CHECK_FILESIZE_ONLY</key>
 				<true />
 			</dict>


### PR DESCRIPTION
Added a filename argument, so a user can specify another name for the dmg to comply to corporate rules, for example.