### PR TITLE
Added filename argument to URLDownloader processor

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -38,6 +38,8 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 			<dict>
 				<key>url</key>
 				<string>https://%DOWNLOAD_URL%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Added a filename argument, so a user can specify another name for the dmg to comply to corporate rules, for example.