### PR TITLE
Removed limit of the feed

### DIFF
--- a/TeXstudio/TeXstudio.download.recipe
+++ b/TeXstudio/TeXstudio.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://sourceforge.net/projects/texstudio/rss?limit=20</string>
+				<string>https://sourceforge.net/projects/texstudio/rss</string>
 				<key>re_pattern</key>
 				<string>https://sourceforge.net/projects/texstudio/files/texstudio/TeXstudio%20(?P&lt;version&gt;[0-9\.]+)/texstudio[_-][0-9\.]+[_-]osx[_-]qt[0-9\.]+\.zip</string>
 			</dict>


### PR DESCRIPTION
The limit to the feed (20) does not reach the latest file. Using 40 as a limit works, but it seems that this is already close to the whole feed, so it is more future proof to not limit the feed. It'd be better if the feed could be retrieved using a platform as a parameter, but I haven't found that yet.