### PR TITLE
Gimp: File name of app has changed

### DIFF
--- a/GIMP/GIMP.munki.recipe
+++ b/GIMP/GIMP.munki.recipe
@@ -55,7 +55,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/GIMP.app</string>
+				<string>%pathname%/G[iI][mM][pP]*.app</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/GIMP.app</string>
 				<key>overwrite</key>


### PR DESCRIPTION
It used to be _GIMP.app_, but with the current version it is _Gimp-2.10.app_. We now use a glob to capture either one and rename to _GIMP.app_.