### PR TITLE
CHECK_FILESIZE_ONLY required

### DIFF
--- a/TeXShop/TeXShop.download.recipe
+++ b/TeXShop/TeXShop.download.recipe
@@ -26,6 +26,8 @@
 				<string>%DOWNLOAD_URL%</string>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
+				<key>CHECK_FILESIZE_ONLY</key>
+				<true/>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Since TeXShop comes from multiple mirrors, download_changed is incorrectly reported unless CHECK_FILESIZE_ONLY is used.