### PR TITLE
Updates to LibreOffice recipes because download URLs changed

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -4,9 +4,6 @@
 <dict>
 	<key>Description</key>
 	<string>Downloads the latest LibreOffice.
-
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>
 	<key>Input</key>

--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest LibreOffice. Set RELEASE to either "fresh" or "still".
+	<string>Downloads the latest LibreOffice.
 
 LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
 LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
@@ -13,8 +13,6 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 	<dict>
 		<key>NAME</key>
 		<string>LibreOffice</string>
-		<key>RELEASE</key>
-		<string>fresh</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -26,9 +24,24 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;DOWNLOAD_URL&gt;download.documentfoundation.org/libreoffice/stable/[\d\.]+/mac/x86_64/LibreOffice_(?P&lt;version&gt;[\d\.]+)_MacOS_x86-64.dmg)</string>
+                <string>(libreoffice.org/donate/dl/mac-x86_64/[\d\.]+/en-US/LibreOffice_(?P&lt;version&gt;[\d\.]+)_MacOS_x86-64.dmg)</string>
 				<key>url</key>
-				<string>https://www.libreoffice.org/download/libreoffice-%RELEASE%/?type=mac-x86_64</string>
+				<string>https://www.libreoffice.org/download/download/?type=mac-x86_64</string>
+                <key>result_output_var_name</key>
+                <string>DONATE_URL</string>
+			</dict>
+		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+				<string>(download.documentfoundation.org/libreoffice/stable/[\d\.]+/mac/x86_64/LibreOffice_[\d\.]+_MacOS_x86-64.dmg)</string>
+				<key>url</key>
+                <string>https://%DONATE_URL%</string>
+                <key>result_output_var_name</key>
+                <string>DOWNLOAD_URL</string>
 			</dict>
 		</dict>
 		<dict>

--- a/LibreOffice/LibreOffice.install.recipe
+++ b/LibreOffice/LibreOffice.install.recipe
@@ -3,18 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Installs the current release version of LibreOffice. Set RELEASE to either "fresh" or "still".
-
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+	<string>Installs the current release version of LibreOffice.
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.install.LibreOffice</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>LibreOffice</string>
-		<key>RELEASE</key>
-		<string>fresh</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>

--- a/LibreOffice/LibreOffice.munki.recipe
+++ b/LibreOffice/LibreOffice.munki.recipe
@@ -3,18 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of LibreOffice and imports into Munki. Set RELEASE to either "fresh" or "still".
-
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+	<string>Downloads the current release version of LibreOffice and imports into Munki.
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.munki.LibreOffice</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>LibreOffice</string>
-		<key>RELEASE</key>
-		<string>fresh</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/LibreOffice</string>
 		<key>MUNKI_CATEGORY</key>

--- a/LibreOffice/LibreOffice.pkg.recipe
+++ b/LibreOffice/LibreOffice.pkg.recipe
@@ -3,18 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of LibreOffice and builds a package. Set RELEASE to either "fresh" or "still".
-
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+	<string>Downloads the current release version of LibreOffice and builds a package.
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.pkg.LibreOffice</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>LibreOffice</string>
-		<key>RELEASE</key>
-		<string>fresh</string>
 	</dict>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>


### PR DESCRIPTION
- Added additional URLTextSearcher processor to LibreOffice download recipe
- Updated URLs to be searched to determine the download URL as the website structure seems to have changed
- Removed references for fresh and still releases as it looks like those release urls now just redirect to the same webpage: https://www.libreoffice.org/download/download/

