### PR TITLE
Update R download to use "mac master server"

### DIFF
--- a/R/R.download.recipe
+++ b/R/R.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://cloud.r-project.org/bin/macosx/</string>
+				<string>https://mac.r-project.org/bin/macosx/</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;r_filename&gt;R-(?P&lt;r_version&gt;[0-9\.]+)\.pkg)</string>
 			</dict>
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://cloud.r-project.org/bin/macosx/%r_filename%</string>
+				<string>https://mac.r-project.org/bin/macosx/%r_filename%</string>
 				<key>filename</key>
 				<string>%NAME%.pkg</string>
 			</dict>


### PR DESCRIPTION
According to the developer (https://stat.ethz.ch/pipermail/r-sig-mac/2019-March/012912.html) the "Mac master server" is located at https://mac.r-project.org/bin/macosx. This server gets updated first apparently then changes get propagated out to the other servers.

Fixes #107