### PR TITLE
Update iLokLicenseManager.munki.recipe

### DIFF
--- a/PACE Anti-Piracy/iLokLicenseManager.munki.recipe
+++ b/PACE Anti-Piracy/iLokLicenseManager.munki.recipe
@@ -125,8 +125,6 @@
 			<dict>
 				<key>input_plist_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Applications/iLok License Manager.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
 			</dict>
 		</dict>
 		<dict>
@@ -139,6 +137,17 @@
 					<key>version</key>
 					<string>%version%</string>
 				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>split_on</key>
+				<string> </string>
+				<key>version</key>
+				<string>%version%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Only the iLok build version is listed for the `CFBundleVersion`.  Changes pull `CFBundleShortVersionString` and split on the space to get the main version number, which matches the pkg install receipts.