### PR TITLE
Update Gimp.pkg.recipe

### DIFF
--- a/GIMP/Gimp.pkg.recipe
+++ b/GIMP/Gimp.pkg.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/GIMP.app</string>
+				<string>%pathname%/GIMP*.app</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/Applications/%NAME%.app</string>
 			</dict>
@@ -72,7 +72,7 @@
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
-					<string>%bundleid%</string>
+					<string>org.gimp.gimp</string>
 					<key>options</key>
 					<string>purge_ds_store</string>
 					<key>chown</key>


### PR DESCRIPTION
Hi,

It seems that the app name in the .dmg has changed, it includes a version number.
Proposal to change line 49 and 75 as a workaround.

Regards,
Manu