### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/GIMP/Gimp.pkg.recipe
+++ b/GIMP/Gimp.pkg.recipe
@@ -48,7 +48,7 @@
 				<key>source_path</key>
 				<string>%pathname%/GIMP.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/GIMP.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -57,7 +57,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>gimp_app_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/GIMP.app</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.