### PR TITLE
Install ksdiff command line tool with Kaleidoscope

### DIFF
--- a/BlackPixel/Kaleidoscope.munki.recipe
+++ b/BlackPixel/Kaleidoscope.munki.recipe
@@ -30,6 +30,16 @@
 			<string>Kaleidoscope</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/bash
+# Install ksdiff command line tool.
+[[ $3 == "/" ]] || exit 1
+KS_APP="/Applications/Kaleidoscope.app"
+KS_BIN_DIR="$KS_APP/Contents/Resources/bin"
+INSTALL_DIR="/usr/local/bin"
+"$KS_APP/Contents/Resources/Integration/scripts/install_ksdiff" "$KS_BIN_DIR" "$INSTALL_DIR"
+exit 0
+</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/BlackPixel/Kaleidoscope.pkg.recipe
+++ b/BlackPixel/Kaleidoscope.pkg.recipe
@@ -72,6 +72,8 @@
 					<string>com.blackpixel.kaleidoscope</string>
 					<key>options</key>
 					<string>purge_ds_store</string>
+					<key>scripts</key>
+					<string>scripts</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/BlackPixel/scripts/postinstall
+++ b/BlackPixel/scripts/postinstall
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Install ksdiff command line tool.
+[[ $3 == "/" ]] || exit 1
+KS_APP="/Applications/Kaleidoscope.app"
+KS_BIN_DIR="$KS_APP/Contents/Resources/bin"
+INSTALL_DIR="/usr/local/bin"
+"$KS_APP/Contents/Resources/Integration/scripts/install_ksdiff" "$KS_BIN_DIR" "$INSTALL_DIR"
+exit 0


### PR DESCRIPTION
This adds a postinstall script for the pkg and munki recipes that installs the `ksdiff` command line tool to /usr/local/bin.

The script always exits zero so that the absence of the `ksdiff` tool will not cause install errors (as would otherwise happen when replacing a MAS version of Kaleidoscope with the AutoPkg-downloaded version).