### PR TITLE
Add VersionSplitter to get actual version of iLok License Manager

### DIFF
--- a/PACE Anti-Piracy/iLokLicenseManager.munki.recipe
+++ b/PACE Anti-Piracy/iLokLicenseManager.munki.recipe
@@ -126,7 +126,16 @@
 				<key>input_plist_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Applications/iLok License Manager.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>version</key>
+				<string>%version%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Apologies, I meant to put this into a separate branch ... let me know if that's a problem for the purposes of this PR.

- Replace CFBundleVersion in `plist_version_key` with CFBundleShortVersionString
- Add VersionSpitter processor to parse at the first space