### PR TITLE
Blender recipe changes

### DIFF
--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Blender.app</string>
 				<key>requirement</key>
 				<string>identifier "org.blenderfoundation.blender" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "68UA947AUU"</string>
 				<key>strict_verification</key>

--- a/Blender/Blender.pkg.recipe
+++ b/Blender/Blender.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Blender.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Blender.app</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Blender.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Consider removing %NAME% variable from .app bundle paths in download and pkg recipes.