### PR TITLE
Remove hardcoded `minimum_os_version`

### DIFF
--- a/DaisyDisk/DaisyDisk.munki.recipe
+++ b/DaisyDisk/DaisyDisk.munki.recipe
@@ -28,8 +28,6 @@
 			<string>Software Ambience Corp.</string>
 			<key>display_name</key>
 			<string>DaisyDisk</string>
-			<key>minimum_os_version</key>
-			<string>10.7</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
Removes the hardcoded `minimum_os_version` value from the DaisyDisk.munki recipe.