### PR TITLE
Adjust name of GitKraken.dmg downloaded file

### DIFF
--- a/Axosoft/GitKraken.download.recipe
+++ b/Axosoft/GitKraken.download.recipe
@@ -22,6 +22,8 @@
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>


### PR DESCRIPTION
Minor change that enables the GitKraken package to appear in alphabetical order under "G" (e.g. `GitKraken-6.4.1.dmg` in a Munki repository, instead of `installGitKraken-6.4.1.dmg`).