### PR TITLE
Update PlexMediaServer recipes to handle zip download

### DIFF
--- a/Plex/PlexMediaServer.download.recipe
+++ b/Plex/PlexMediaServer.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://plex.tv/pms/downloads/5.json</string>
 				<key>re_pattern</key>
-				<string>(https://downloads.plex.tv/plex-media-server-new/[0-9\.]+-[a-z0-9]+/macos/PlexMediaServer-[0-9\.]+-[a-z0-9]+-x86_64\.dmg)</string>
+				<string>(https://downloads.plex.tv/plex-media-server-new/[0-9\.]+-[a-z0-9]+/macos/PlexMediaServer-[0-9\.]+-[a-z0-9]+-x86_64\.zip)</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 			</dict>
@@ -34,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%.zip</string>
 			</dict>
 		</dict>
 		<dict>
@@ -43,11 +43,24 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Plex Media Server.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Plex Media Server.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.plexapp.plexmediaserver" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = K4QJ56KR4A)</string>
 				<key>strict_verification</key>

--- a/Plex/PlexMediaServer.munki.recipe
+++ b/Plex/PlexMediaServer.munki.recipe
@@ -32,21 +32,23 @@
 			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
+			<key>blocking_applications</key>
+			<array>
+				<string>Plex Media Server.app</string>
+			</array>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.4</string>
 	<key>ParentRecipe</key>
-	<string>io.github.hjuutilainen.download.PlexMediaServer</string>
+	<string>io.github.hjuutilainen.pkg.PlexMediaServer</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
-				<key>munkiimport_appname</key>
-				<string>Plex Media Server.app</string>
+				<string>%pkg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Plex/PlexMediaServer.pkg.recipe
+++ b/Plex/PlexMediaServer.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>pkgdirs</key>
 				<dict>
 					<key>Applications</key>
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/Plex Media Server.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Plex Media Server.app</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/Applications/Plex Media Server.app</string>
 			</dict>


### PR DESCRIPTION
- `PlexMediaServer.download.recipe` recipe downloads **zip** file since they changed their distribution method from dmg
- `PlexMediaServer.munki.recipe` recipe now import the pkg instead of dmg.

Fixes #125 