### PR TITLE
Update GIMP.download.recipe

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -21,9 +21,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>href="0.0_LATEST-IS-(?P&lt;full_version&gt;[\d\.]+)"</string>
+				<string>&gt;(gimp-.*-x86_64.dmg)&lt;</string>
 				<key>url</key>
-				<string>https://download.gimp.org/pub/gimp/stable/</string>
+				<string>https://download.gimp.org/pub/gimp/stable/osx/?C=M;O=D</string>
 			</dict>
 		</dict>
 		<dict>
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://download.gimp.org/pub/gimp/stable/osx/gimp-%full_version%-x86_64.dmg</string>
+				<string>https://download.gimp.org/pub/gimp/stable/osx/%match%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Changed URLTextsearcher to lookg for latest version at https://download.gimp.org/pub/gimp/stable/osx/?C=M;O=D, as the LATEST file says 2.10.16 but there isn't 2.10.16 for macOS.