### PR TITLE
Update Kaleidoscope for new parent company cert

### DIFF
--- a/BlackPixel/Kaleidoscope.download.recipe
+++ b/BlackPixel/Kaleidoscope.download.recipe
@@ -55,7 +55,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Kaleidoscope.app</string>
 				<key>requirement</key>
-				<string>identifier "com.blackpixel.kaleidoscope" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "432ZXYXDNY"</string>
+				<string>anchor apple generic and identifier "com.blackpixel.kaleidoscope" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = GLNN8MJNQ8)</string>
 				<key>strict_verification</key>
 				<true />
 			</dict>


### PR DESCRIPTION
Black Pixel was acquired by a company called Hypergiant, and they seem to now be using their team ID for this product (app store and other BlackPixel products seem unchanged). Updating CodeSigVerification accordingly