### PR TITLE
Update TeamViewer QS minimum_os_version to 10.13.6

### DIFF
--- a/TeamViewer/TeamViewerQuickSupport.munki.recipe
+++ b/TeamViewer/TeamViewerQuickSupport.munki.recipe
@@ -34,7 +34,7 @@
 			<key>display_name</key>
 			<string>TeamViewer QuickSupport</string>
 			<key>minimum_os_version</key>
-			<string>10.5</string>
+			<string>10.13.6</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
TeamViewer 15.3 now has `minimum_os_version` set to 10.13.6.