### PR TITLE
Fix for R recipes

### DIFF
--- a/R/R.munki.recipe
+++ b/R/R.munki.recipe
@@ -68,7 +68,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/r.pkg/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/R-fw.pkg/Payload</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/root/Library/Frameworks</string>
 			</dict>
@@ -90,7 +90,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/r-1.pkg/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/R-app.pkg/Payload</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/root/Applications</string>
 			</dict>


### PR DESCRIPTION
Looks like the names of the sub packages have changed in the R distribution package.  The GUI app is now in R-app.pkg and the framework is now in R-fw.pkg.

This pull request changes the paths in the PkgPayloadUnpacker phases of the R.munki recipe to reflect that change.