### PR TITLE
Kaleidoscope - update to new Sparkle URL

### DIFF
--- a/BlackPixel/Kaleidoscope.download.recipe
+++ b/BlackPixel/Kaleidoscope.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Kaleidoscope</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>https://updates.blackpixel.com/updates?app=ks</string>
+		<string>https://appcasts.hypergiant.com/ks/prod/updates</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>


### PR DESCRIPTION
I got an expired SSL error on the existing Sparkle URL today:

<img width="1903" alt="Screen Shot 2020-06-15 at 4 18 34 PM" src="https://user-images.githubusercontent.com/23509619/84716199-530a7100-af27-11ea-882a-21463c597580.png">

No biggie, things happen. Kind of odd though that they haven't fixed it yet.

Upon looking into it further the latest app downloaded from the Kaleidoscope project page has this Sparkle URL in the Info.plist

```
	<key>SUFeedURL</key>
	<string>https://appcasts.hypergiant.com/ks/prod/updates</string>
```

I updated the recipe to use that and things continue to work as expected.

Relevant AutoPkg logs:

```
 'SPARKLE_FEED_URL': 'https://appcasts.hypergiant.com/ks/prod/updates',
 'verbose': 4}
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://appcasts.hypergiant.com/ks/prod/updates'}}
SparkleUpdateInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://appcasts.hypergiant.com/ks/prod/updates']
SparkleUpdateInfoProvider: Version retrieved from appcast: 1441
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.3.1
SparkleUpdateInfoProvider: Found URL https://appcasts.hypergiant.com/ks/prod/Kaleidoscope-2.3.1-build-1441-apr-7-2020.zip
{'Output': {'url': 'https://appcasts.hypergiant.com/ks/prod/Kaleidoscope-2.3.1-build-1441-apr-7-2020.zip',
            'version': '2.3.1'}}
URLDownloader
{'Input': {'url': 'https://appcasts.hypergiant.com/ks/prod/Kaleidoscope-2.3.1-build-1441-apr-7-2020.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://appcasts.hypergiant.com/ks/prod/Kaleidoscope-2.3.1-build-1441-apr-7-2020.zip', '--fail', '--output', '/Users/brandonfriess/Library/AutoPkg/Cache/com.stripe.autopkg.kaleidoscope.download/downloads/tmpwexlxms_', '--header', 'If-None-Match: "339e0d920bb0a38d9c3dce5f14f7e097-4"', '--header', 'If-Modified-Since: Wed, 08 Apr 2020 01:48:56 GMT']
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/brandonfriess/Library/AutoPkg/Cache/com.stripe.autopkg.kaleidoscope.download/downloads/Kaleidoscope-2.3.1-build-1441-apr-7-2020.zip
{'Output': {'pathname': '/Users/brandonfriess/Library/AutoPkg/Cache/com.stripe.autopkg.kaleidoscope.download/downloads/Kaleidoscope-2.3.1-build-1441-apr-7-2020.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
```