### PR TITLE
Add OPTIONAL_VERSION key for downloading open source Elastic Beats

### DIFF
--- a/Elasticsearch/elasticbeat.download.recipe
+++ b/Elasticsearch/elasticbeat.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest defined Elastic Beat product. Set BEAT_NAME to one of the following: filebeat, packetbeat, metricbeat, heartbeat, auditbeat, functionbeat. Note: winlogbeat and journalbeat do not have macOS binaries</string>
+	<string>Downloads the latest defined Elastic Beat product. Use an override to set OPTIONAL_VERSION to -oss to download the Apache 2.0 licensed version of the Beat. Set BEAT_NAME to one of the following: filebeat, packetbeat, metricbeat, heartbeat, auditbeat, functionbeat. Note: winlogbeat and journalbeat do not have macOS binaries and functionbeat does not have an Apache 2.0 licensed version.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.elasticbeat</string>
 	<key>Input</key>
@@ -12,6 +12,8 @@
 		<string>filebeat</string>
 		<key>NAME</key>
 		<string>filebeat</string>
+		<key>OPTIONAL_VERSION</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.4</string>
@@ -23,9 +25,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://www.elastic.co/downloads/beats/%BEAT_NAME%</string>
+				<string>https://www.elastic.co/downloads/beats/%BEAT_NAME%%OPTIONAL_VERSION%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https://artifacts.elastic.co/downloads/beats/%BEAT_NAME%/%BEAT_NAME%-(?P&lt;version&gt;[\d\.]+)-darwin-x86_64\.tar\.gz)</string>
+				<string>(?P&lt;url&gt;https://artifacts.elastic.co/downloads/beats/%BEAT_NAME%/%BEAT_NAME%%OPTIONAL_VERSION%-(?P&lt;version&gt;[\d\.]+)-darwin-x86_64\.tar\.gz)</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://artifacts.elastic.co/downloads/beats/%BEAT_NAME%/%BEAT_NAME%-%version%-darwin-x86_64.tar.gz.sha512</string>
+				<string>https://artifacts.elastic.co/downloads/beats/%BEAT_NAME%/%BEAT_NAME%%OPTIONAL_VERSION%-%version%-darwin-x86_64.tar.gz.sha512</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;checksum&gt;\w+)</string>
 			</dict>


### PR DESCRIPTION
The current Elastic Beats recipes can only download the proprietary Elastic License versions of each Beat. This adds `OPTIONAL_VERSION, an empty by default key that can be set to `-oss` for downloading the Apache 2.0 version. This is useful because the AWS version of ElasticSearch only works with the Apache 2.0 packages.

I've tested this against every Beat recipe in this repo except function beat, which does not have a freely licensed version.