### PR TITLE
Update sparkle feed URL

### DIFF
--- a/iTerm2/iTerm2.download.recipe
+++ b/iTerm2/iTerm2.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current version of iTerm2. Set RELEASE to either "final" or "testing". For iTerm2 version 3 beta, set RELEASE to "testing3".</string>
+	<string>Downloads the current version of iTerm2. Set RELEASE to either "final_modern" or "testing_modern".</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.iTerm2</string>
 	<key>Input</key>
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>iTerm2</string>
 		<key>RELEASE</key>
-		<string>final</string>
+		<string>final_modern</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>

--- a/iTerm2/iTerm2.munki.recipe
+++ b/iTerm2/iTerm2.munki.recipe
@@ -15,7 +15,7 @@
 		<key>MUNKI_CATEGORY</key>
 		<string>Utilities</string>
 		<key>RELEASE</key>
-		<string>final</string>
+		<string>final_modern</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>


### PR DESCRIPTION
Looks like the existing sparkle feed (https://www.iterm2.com/appcasts/final.xml) is not including the latest releases (3.4.0 and 3.4.1). The new versions are showing up here: https://www.iterm2.com/appcasts/final_modern.xml

Changed the release key in the .download recipe to reflect the change and updated the description.

I've also updated the release key in the .munki recipe to match.