### PR TITLE
Update 1Password.munki.recipe

### DIFF
--- a/AgileBits/1Password.munki.recipe
+++ b/AgileBits/1Password.munki.recipe
@@ -36,6 +36,14 @@
 			<string>10.12</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+ 			<string>#!/bin/zsh
+
+  if
+ 	[[ -e /Applications/1Password\ 7.app.zip ]]
+ 	then
+ 	/bin/rm /Applications/1Password\ 7.app.zip
+ fi</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>


### PR DESCRIPTION
The 1Password 7 installer has a preinstall script that zips up existing copies of the app and then leaves them in the /Applications folder when it is done.

This postinstall_script will look for that zip and remove it.