### PR TITLE
Add `filename` support in TeamViewerQuickSupport.download.recipe

### DIFF
--- a/TeamViewer/TeamViewerQuickSupport.download.recipe
+++ b/TeamViewer/TeamViewerQuickSupport.download.recipe
@@ -24,6 +24,8 @@
 			<dict>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Added the `filename` input key for URLDownloader processor.
It doesn't cost much and would allow a bit more control over the filename that is later imported in the Munki recipe, for example.