### PR TITLE
Adjust PkgCopier arguments

### DIFF
--- a/AgileBits/1Password.pkg.recipe
+++ b/AgileBits/1Password.pkg.recipe
@@ -39,8 +39,6 @@
 				<string>%pathname%</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>purge_destination</key>
-				<true/>
 			</dict>
 		</dict>
 		<dict>

--- a/F-Secure/Freedome.pkg.recipe
+++ b/F-Secure/Freedome.pkg.recipe
@@ -39,8 +39,6 @@
 				<string>%pathname%</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>purge_destination</key>
-				<true/>
 			</dict>
 		</dict>
 		<dict>

--- a/Hannes Juutilainen/BigSurBlocker.pkg.recipe
+++ b/Hannes Juutilainen/BigSurBlocker.pkg.recipe
@@ -26,8 +26,6 @@
 				<string>%pathname%</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>purge_destination</key>
-				<true/>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
`purge_destination` is not a valid input variable for [PkgCopier](https://github.com/autopkg/autopkg/wiki/Processor-PkgCopier), and has no effect here.