### PR TITLE
The new minimum is macOS 10.15

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -33,7 +33,7 @@
 			<key>display_name</key>
 			<string>Citrix Workspace</string>
 			<key>minimum_os_version</key>
-			<string>10.10</string>
+			<string>10.15</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
When attempting to install on 10.14, the installation specifically calls out that it needs 10.15.

$sudo installer -target / -pkg /Volumes/Citrix\ Workspace/Install\ Citrix\ Workspace.pkg 
installer: Error - Citrix Workspace requires macOS 10.15 Catalina or later.