### PR TITLE
Remove no longer needed minimum_os_version var in iTerm2 munki recipe

### DIFF
--- a/iTerm2/iTerm2.munki.recipe
+++ b/iTerm2/iTerm2.munki.recipe
@@ -30,8 +30,6 @@
 			<string>George Nachman</string>
 			<key>display_name</key>
 			<string>%NAME%</string>
-			<key>minimum_os_version</key>
-			<string>10.5</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
LSMinimumSystemVersion is populated in app.