### PR TITLE
Add additional 'installs' keys to pkginfo

### DIFF
--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -51,6 +51,15 @@
 			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
+					<key>installs</key>
+					<array>
+					<dict>
+						<key>path</key>
+						<string>/Applications/TeamViewer.app</string>
+						<key>type</key>
+						<string>application</string>
+					</dict>
+					</array>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>


### PR DESCRIPTION
This PR fixes the issue recorded in #178.
This PR automatically add a 'path' and 'type' key into the 'installs' key in the TeamViewer pkginfo using the MunkiPkginfoMerger processor.
The recipes have been tested and are functional:

 'pkginfo': {'catalogs': ['testing'],
             'category': 'Internet',
             'description': 'All-In-One Solution for Remote Access and Support '
                            'over the Internet.',
             'developer': 'TeamViewer GmbH',
             'display_name': 'TeamViewer',
             'installs': [{'path': '/Applications/TeamViewer.app',
                           'type': 'application'}],
             'minimum_os_version': '10.13.6',
             'name': 'TeamViewer',
             'unattended_install': True,
             'unattended_uninstall': True,
             'version': '15.16.8'},
 'pkginfo_repo_path': '/Volumes/munki_repo_test/pkgsinfo/apps/TeamViewer/TeamViewer-15.16.8.plist',
 'pkgroot': '/Users/setup/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/payload/root/Applications',
 'plist_keys': {'CFBundleShortVersionString': 'version'},
 'plist_reader_output_variables': {'version': '15.16.8'},
 'prefetch_filename': False,
 'repo_subdirectory': 'apps/TeamViewer',
 'source_pkg': '/Users/setup/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/downloads/TeamViewer.dmg/Install '
               'TeamViewer.app/Contents/Resources/Install TeamViewer.pkg',
 'url': 'https://download.teamviewer.com/download/TeamViewer.dmg',
 'verbose': 3,
 'version': '15.16.8'}
Receipt written to /Users/setup/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/receipts/TeamViewer.munki-receipt-20210326-153241.plist

The following packages were copied:
    Pkg Path                                                                                           
    --------                                                                                           
    /Users/setup/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/TeamViewer-15.16.8.pkg  

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                              Pkg Repo Path                           Icon Repo Path  
    ----        -------  --------  ------------                              -------------                           --------------  
    TeamViewer  15.16.8  testing   apps/TeamViewer/TeamViewer-15.16.8.plist  apps/TeamViewer/TeamViewer-15.16.8.pkg  