### PR TITLE
Mark receipts as optional to avoid TeamViewer install loop

### DIFF
--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -67,6 +67,18 @@
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 		</dict>
+    <dict>
+      <key>Arguments</key>
+      <dict>
+        <key>pkg_ids_set_optional_true</key>
+        <array>
+          <string>com.teamviewer.RemotePrintingPackage</string>
+          <string>com.teamviewer.teamviewerSilentInstaller</string>
+        </array>
+      </dict>
+      <key>Processor</key>
+      <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+    </dict>
 	</array>
 </dict>
 </plist>

--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -67,18 +67,18 @@
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 		</dict>
-    <dict>
-      <key>Arguments</key>
-      <dict>
-        <key>pkg_ids_set_optional_true</key>
-        <array>
-          <string>com.teamviewer.RemotePrintingPackage</string>
-          <string>com.teamviewer.teamviewerSilentInstaller</string>
-        </array>
-      </dict>
-      <key>Processor</key>
-      <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
-    </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_ids_set_optional_true</key>
+				<array>
+					<string>com.teamviewer.RemotePrintingPackage</string>
+					<string>com.teamviewer.teamviewerSilentInstaller</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Using the current recipe, Munki/MSC will not recognize TeamViewer as being installed after installation. This will cause Munki to repeatedly reinstall the package.

This PR declares the two problematic receipts as optional, fixing the issue.