### PR TITLE
TeamViewer Installs/Optional Receipts fix

### DIFF
--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -67,18 +67,6 @@
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_ids_set_optional_true</key>
-				<array>
-					<string>com.teamviewer.RemotePrintingPackage</string>
-					<string>com.teamviewer.teamviewerSilentInstaller</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
-		</dict>
 	</array>
 </dict>
 </plist>

--- a/TeamViewer/TeamViewer.pkg.recipe
+++ b/TeamViewer/TeamViewer.pkg.recipe
@@ -65,15 +65,21 @@
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
-       <dict>
-           <key>Arguments</key>
-           <dict>
-               <key>info_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload/root/Applications/TeamViewer.app</string>
-           </dict>
-           <key>Processor</key>
-           <string>PlistReader</string>
-       </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict/>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/root/Applications/TeamViewer.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The current munki recipe utilizes the MunkiPkginfoReceiptsEditor processor. This processor functions by making changes to the pkginfo flat file. When using a munki repo that is not flat-file based, the processor fails because it cannot open and modify the pkginfo. As a result, the recipe fails to add the optional keys to the receipts array if the munki repository is not a local or mounted folder.

Interestingly enough, the `TeamViewer.pkg.recipe` implements the `MunkiInstallsItemsCreator` as noted by @hansen-m in https://github.com/autopkg/hjuutilainen-recipes/issues/173. This information is lost (not committed to the final pkginfo), however, as there is no necessary `MunkiPkginfoMerger` processor included after. 

This MR removes the troublesome optional receipts approach and adds `MunkiPkginfoMerger` so that the installs approach may be used.

