### PR TITLE
TeamViewer Munki Uninstall Fix

### DIFF
--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -36,6 +36,9 @@
 			<true/>
 			<key>unattended_uninstall</key>
 			<true/>
+      <key>postuninstall_script</key>
+      <string>#!/bin/bash
+rm -rf /Applications/TeamViewer.app</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
Yet another TeamViewer-related PR. This one fixes the uninstall issue. The current recipe does not remove `/Applications/TeamViewer.app` during uninstall. This adds a `postuninstall_script` to manually remove it.