### PR TITLE
Update R.download regex

### DIFF
--- a/R/R.download.recipe
+++ b/R/R.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://cloud.r-project.org/bin/macosx/</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;r_filename&gt;R-(?P&lt;r_version&gt;[0-9\.]+)\.pkg)</string>
+				<string>(?P&lt;r_filename&gt;base\/R-(?P&lt;r_version&gt;[0-9\.]+)\.pkg)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The product page now has a binary for Intel and one for ARM, but not Universal.
The format of the download URL changed due to this. Since this recipe was for Intel previously, the edit I made was to target the Intel binary.
There is now a preceding directory of `base` in the path and that is collected as part of the filename regex capture.
After making this edit, the recipe successfully downloads version 4.1.0 for Intel.