### PR TITLE
Changed download strategy for LibreOffice

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -35,24 +35,13 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		</dict>
 		<dict>
 			<key>Comment</key>
-			<string>Validate the version we found above by searching the download page</string>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>(?P&lt;DOWNLOAD_URL&gt;download.documentfoundation.org/libreoffice/stable/%version%/mac/x86_64/LibreOffice_%version%_MacOS_x86-64.dmg)</string>
-				<key>url</key>
-				<string>https://www.libreoffice.org/download/download/?type=mac-x86_64</string>
-			</dict>
-		</dict>
-		<dict>
+			<string>Attempt to download LibreOffice using the last known download naming convention</string>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://%DOWNLOAD_URL%</string>
+				<string>https://download.documentfoundation.org/libreoffice/stable/%version%/mac/x86_64/LibreOffice_%version%_MacOS_x86-64.dmg</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Download links on LibreOffice actually go via a donate page, so the direct links to the files are no longer present within the download page. 

I propose that we skip validating the download links, and just attempt to download LibreOffice based on the version and the last known download link structure.

This PR removes the validation step so that this recipe works again.

Output of `autopkg run -v LibreOffice.download.recipe`:
```
Processing LibreOffice.download.recipe...
WARNING: LibreOffice.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 7.1.3
URLTextSearcher: Found matching text (match): 7.1.3
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 29 Apr 2021 22:50:14 GMT
URLDownloader: Storing new ETag header: "590384815-1040364c-5c124518abc86"
URLDownloader: Downloaded /Users/jc0b/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/jc0b/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.z6BWH9/LibreOffice.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.z6BWH9/LibreOffice.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.z6BWH9/LibreOffice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/jc0b/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/receipts/LibreOffice.download-receipt-20210615-114121.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/jc0b/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice.dmg
```