### PR TITLE
Update LibreOffice.download.recipe

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -35,24 +35,19 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		</dict>
 		<dict>
 			<key>Comment</key>
-			<string>Validate the version we found above by searching the download page</string>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>(?P&lt;DOWNLOAD_URL&gt;download.documentfoundation.org/libreoffice/stable/%version%/mac/x86_64/LibreOffice_%version%_MacOS_x86-64.dmg)</string>
-				<key>url</key>
-				<string>https://www.libreoffice.org/download/download/?type=mac-x86_64</string>
-			</dict>
-		</dict>
-		<dict>
+			<string>
+				The current (late June 2021) dmg download URL at
+				https://www.libreoffice.org/download/download/?type=mac-x86_64
+				takes us to a JavaScript-heavy page that eventually redirects to
+				the download, but the download is at a predictable URL once we
+				know the version. So we just assemble that URL.
+			</string>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://%DOWNLOAD_URL%</string>
+				<string>https://download.documentfoundation.org/libreoffice/stable/%version%/mac/x86_64/LibreOffice_%version%_MacOS_x86-64.dmg</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Download URL is still the calculated one, but no longer directly listed on the download page. So just try it "blindly". Works as of June 30, 2021...