### PR TITLE
Removed checking the minimum compatible version for Citrix Workspace

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -96,8 +96,6 @@
 				<dict>
 					<key>CFBundleShortVersionString</key>
 					<string>version</string>
-					<key>LSMinimumSystemVersion</key>
-					<string>min_os_version</string>
 				</dict>
 			</dict>
 			<key>Processor</key>
@@ -108,8 +106,6 @@
 			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
-					<key>minimum_os_version</key>
-					<string>%min_os_version%</string>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>

--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -106,6 +106,8 @@
 			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
+					<key>minimum_os_version</key>
+					<string>10.15</string>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>


### PR DESCRIPTION
Citrix Workspace hasn't been compatible with a macOS version less than 10.15 for quite some time. Despite this, the Info.plist contained within the Citrix Workspace .app lists the ```LSMinimumVersion``` as 10.11. 

This recipe currently checks that value to determine the minimum version of macOS required for Citrix, but this then returns the wrong value for the minimum OS version. The installer uses a helper tool to assess compatibility with the host Mac, so we don't seem to be able to dynamically grab the lowest supported version from the installer either. As a result, for now, I've hardcoded the value into the recipe with the idea that the value gets updated each time Citrix changes their requirements for Workspace.

Citrix Workspace system requirements: https://docs.citrix.com/en-us/citrix-workspace-app-for-mac/system-requirements.html