### PR TITLE
Update regular expression for Citrix Receiver download dmg

### DIFF
--- a/CitrixReceiver/CitrixReceiver.download.recipe
+++ b/CitrixReceiver/CitrixReceiver.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://www.citrix.com/downloads/citrix-receiver/mac/receiver-for-mac-latest.html</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;DYNAMIC_URL&gt;//downloads.citrix.com/[\d]+/CitrixReceiver\.dmg\?__gda__\=[\w]+)</string>
+				<string>(?P&lt;DYNAMIC_URL&gt;//downloads.citrix.com/[\d]+/CitrixReceiver\.dmg\?__gda__\=[\S][^"]+)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The end of the new regular expression matches "all non-whitespace except double-quote," and seems to capture the various characters needed for the dmg download URL.

Before:

```
% autopkg run -vv CitrixReceiver/CitrixReceiver.download.recipe 
Processing CitrixReceiver/CitrixReceiver.download.recipe...
WARNING: CitrixReceiver/CitrixReceiver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<DYNAMIC_URL>//downloads.citrix.com/[\\d]+/CitrixReceiver\\.dmg\\?__gda__\\=[\\w]+)',
           'url': 'https://www.citrix.com/downloads/citrix-receiver/mac/receiver-for-mac-latest.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (DYNAMIC_URL): //downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp
URLTextSearcher: Found matching text (match): //downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp
{'Output': {'DYNAMIC_URL': '//downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp',
            'match': '//downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp'}}
URLDownloader
{'Input': {'filename': 'CitrixReceiver.dmg',
           'url': 'https://downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp', '--fail', '--output', '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/tmp835ny51w']' returned non-zero exit status 22.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/receipts/CitrixReceiver.download-receipt-20210918-170537.plist

The following recipes failed:
    CitrixReceiver/CitrixReceiver.download.recipe
        Error in io.github.hjuutilainen.download.CitrixReceiver: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp', '--fail', '--output', '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/tmp835ny51w']' returned non-zero exit status 22.
```

After:

```
% autopkg run -vv CitrixReceiver/CitrixReceiver.download.recipe
Processing CitrixReceiver/CitrixReceiver.download.recipe...
WARNING: CitrixReceiver/CitrixReceiver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<DYNAMIC_URL>//downloads.citrix.com/[\\d]+/CitrixReceiver\\.dmg\\?__gda__\\=[\\S][^"]+)',
           'url': 'https://www.citrix.com/downloads/citrix-receiver/mac/receiver-for-mac-latest.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (DYNAMIC_URL): //downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp=1632014864~acl=/*~hmac=964a690a6cc89e2485a42a38297cf61868d93296a0333f55c5d798a893c0aded
URLTextSearcher: Found matching text (match): //downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp=1632014864~acl=/*~hmac=964a690a6cc89e2485a42a38297cf61868d93296a0333f55c5d798a893c0aded
{'Output': {'DYNAMIC_URL': '//downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp=1632014864~acl=/*~hmac=964a690a6cc89e2485a42a38297cf61868d93296a0333f55c5d798a893c0aded',
            'match': '//downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp=1632014864~acl=/*~hmac=964a690a6cc89e2485a42a38297cf61868d93296a0333f55c5d798a893c0aded'}}
URLDownloader
{'Input': {'filename': 'CitrixReceiver.dmg',
           'url': 'https://downloads.citrix.com/14596/CitrixReceiver.dmg?__gda__=exp=1632014864~acl=/*~hmac=964a690a6cc89e2485a42a38297cf61868d93296a0333f55c5d798a893c0aded'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 02 May 2018 13:39:58 GMT
URLDownloader: Storing new ETag header: "93544a12d3c71909fcfda92862982c75:1525268398"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/CitrixReceiver.dmg
{'Output': {'download_changed': True,
            'etag': '"93544a12d3c71909fcfda92862982c75:1525268398"',
            'last_modified': 'Wed, 02 May 2018 13:39:58 GMT',
            'pathname': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/CitrixReceiver.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/CitrixReceiver.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Citrix '
                                        'Systems, Inc. (KBVSJ83SS9)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/CitrixReceiver.dmg/Install '
                         'Citrix Receiver.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/CitrixReceiver.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Citrix Receiver.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2018-04-28 04:02:20 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Citrix Systems, Inc. (KBVSJ83SS9)
CodeSignatureVerifier:        Expires: 2022-04-01 19:52:20 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F3 FB 5A E9 41 CA 78 CB FD 82 4A 93 99 34 49 11 34 2A 4E 60 F0 72 
CodeSignatureVerifier:            86 62 A1 A7 75 12 1C D1 8D EC
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/receipts/CitrixReceiver.download-receipt-20210918-172751.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.CitrixReceiver/downloads/CitrixReceiver.dmg
```