### PR TITLE
Adjust regular expression for GIMP download, allowing detection of version 2.10.24

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -34,11 +34,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>&gt;(gimp-.*-x86_64[\-0-9]*-1\.dmg)&lt;</string>
+				<string>&gt;(gimp-[\d\.]+-x86_64(-\d)?\.dmg)&lt;</string>
 				<key>url</key>
 				<string>https://download.gimp.org/pub/gimp/v%version_match%/osx/?C=N;O=D</string>
 				<key>result_output_var_name</key>
-				<string>dmg_match</string>				
+				<string>dmg_match</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Fixes https://github.com/autopkg/hjuutilainen-recipes/issues/202.

Run output:

```
% autopkg run -vvcq GIMP/GIMP.download.recipe
Processing GIMP/GIMP.download.recipe...
WARNING: GIMP/GIMP.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': "href='//download.gimp.org/mirror/pub/gimp/v(.*)/osx/'",
           'result_output_var_name': 'version_match',
           'url': 'https://www.gimp.org/downloads/'}}
URLTextSearcher: Found matching text (version_match): 2.10
{'Output': {'version_match': '2.10'}}
URLTextSearcher
{'Input': {'re_pattern': '>(gimp-[\\d\\.]+-x86_64(-\\d)?\\.dmg)<',
           'result_output_var_name': 'dmg_match',
           'url': 'https://download.gimp.org/pub/gimp/v2.10/osx/?C=N;O=D'}}
URLTextSearcher: Found matching text (dmg_match): gimp-2.10.24-x86_64.dmg
{'Output': {'dmg_match': 'gimp-2.10.24-x86_64.dmg'}}
URLDownloader
{'Input': {'filename': 'GIMP.dmg',
           'url': 'https://download.gimp.org/pub/gimp/v2.10/osx/gimp-2.10.24-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 25 Jul 2021 23:18:21 GMT
URLDownloader: Storing new ETag header: "77b0c0a-5c7fada410940"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.GIMP/downloads/GIMP.dmg
{'Output': {'download_changed': True,
            'etag': '"77b0c0a-5c7fada410940"',
            'last_modified': 'Sun, 25 Jul 2021 23:18:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.GIMP/downloads/GIMP.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.GIMP/downloads/GIMP.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.GIMP/receipts/GIMP.download-receipt-20211007-103823.plist

The following new items were downloaded:
    Download Path                                                                                 
    -------------                                                                                 
    ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.GIMP/downloads/GIMP.dmg
```