### PR TITLE
use CFBundleVersion instead of the short version

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -94,7 +94,7 @@
 				<string>%RECIPE_CACHE_DIR%/payload/Applications/Citrix Workspace.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
-					<key>CFBundleShortVersionString</key>
+					<key>CFBundleVersion</key>
 					<string>version</string>
 				</dict>
 			</dict>
@@ -138,6 +138,8 @@
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
The latest update isn't coming through AutoPKG due to the short version being used.

Final stretch of the output when running the altered recipe:

```
 'plist_keys': {'CFBundleVersion': 'version'},
 'plist_reader_output_variables': {'version': '700021.11.0.28'},
 'prefetch_filename': False,
 're_pattern': '(?P<DYNAMIC_URL>//downloads.citrix.com/[\\d]+/CitrixWorkspaceApp\\.dmg\\?__gda__\\=[\\w]+\\=[\\w]+\\~[\\w]+\\=/\\*\\~[\\w]+\\=[\\w]+)',
 'repo_subdirectory': 'apps/Citrix',
 'result_output_var_name': 'match',
 'url': 'https://downloads.citrix.com/20114/CitrixWorkspaceApp.dmg?__gda__=exp=1637934706~acl=/*~hmac=f896a34bd905de2ce7a59b060283393c01fc5eca7cc8744479b354daee31c8d9',
 'verbose': 3,
 'version': '700021.11.0.28',
 'version_comparison_key': 'CFBundleVersion'}
Receipt written to /Users/frank/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/receipts/CitrixWorkspace.munki-receipt-20211126-135350.plist

The following new items were imported into Munki:
    Name             Version         Catalogs  Pkginfo Path                                      Pkg Repo Path                                   Icon Repo Path  
    ----             -------         --------  ------------                                      -------------                                   --------------  
    CitrixWorkspace  700021.11.0.28  testing   apps/Citrix/CitrixWorkspace-700021.11.0.28.plist  apps/Citrix/CitrixWorkspace-700021.11.0.28.dmg
```