### PR TITLE
TeamViewer Host improvements

### DIFF
--- a/TeamViewer/TeamViewerHost.munki.recipe
+++ b/TeamViewer/TeamViewerHost.munki.recipe
@@ -9,32 +9,32 @@
     <key>Input</key>
     <dict>
         <key>MUNKI_CATEGORY</key>
-		<string>Internet</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/teamviewer</string>
+        <string>Internet</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/teamviewer</string>
         <key>NAME</key>
         <string>TeamViewerHost</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>category</key>
-			<string>%MUNKI_CATEGORY%</string>
-			<key>description</key>
-			<string>All-In-One Solution for Remote Access and Support over the Internet.</string>
-			<key>developer</key>
-			<string>TeamViewer GmbH</string>
-			<key>display_name</key>
-			<string>TeamViewer Host</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-			<key>unattended_uninstall</key>
-			<true/>
-		</dict>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>description</key>
+            <string>All-In-One Solution for Remote Access and Support over the Internet.</string>
+            <key>developer</key>
+            <string>TeamViewer GmbH</string>
+            <key>display_name</key>
+            <string>TeamViewer Host</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/TeamViewer/TeamViewerHost.munki.recipe
+++ b/TeamViewer/TeamViewerHost.munki.recipe
@@ -19,39 +19,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>flat_pkg_path</key>
-                <string>%pkg_path%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-                <key>pkgdirs</key>
-                <dict/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerHostApp.pkg/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
@@ -76,18 +43,6 @@
                 <string>%pkg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/</string>
-                    <string>%RECIPE_CACHE_DIR%/unpack/</string>
-                </array>
             </dict>
         </dict>
     </array>

--- a/TeamViewer/TeamViewerHost.munki.recipe
+++ b/TeamViewer/TeamViewerHost.munki.recipe
@@ -8,8 +8,33 @@
     <string>io.github.hjuutilainen.munki.TeamViewerHost</string>
     <key>Input</key>
     <dict>
+        <key>MUNKI_CATEGORY</key>
+		<string>Internet</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/teamviewer</string>
         <key>NAME</key>
         <string>TeamViewerHost</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>description</key>
+			<string>All-In-One Solution for Remote Access and Support over the Internet.</string>
+			<key>developer</key>
+			<string>TeamViewer GmbH</string>
+			<key>display_name</key>
+			<string>TeamViewer Host</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
@@ -23,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <string>%RECIPE_CACHE_DIR%/payload/root</string>
                 <key>installs_item_paths</key>
                 <array>
                     <string>/Applications/TeamViewerHost.app</string>
@@ -44,6 +69,18 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/TeamViewer/TeamViewerHost.pkg.recipe
+++ b/TeamViewer/TeamViewerHost.pkg.recipe
@@ -79,18 +79,6 @@
             <key>Processor</key>
             <string>PkgCopier</string>
         </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
-                    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/TeamViewer/TeamViewerHost.pkg.recipe
+++ b/TeamViewer/TeamViewerHost.pkg.recipe
@@ -52,26 +52,21 @@
             <key>Processor</key>
             <string>PkgPayloadUnpacker</string>
         </dict>
-       <dict>
-           <key>Arguments</key>
-           <dict>
-               <key>info_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload/root/Applications/TeamViewerHost.app</string>
-           </dict>
-           <key>Processor</key>
-           <string>PlistReader</string>
-       </dict>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
-                    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload/root/Applications/TeamViewerHost.app</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_version</string>
+                </dict>
             </dict>
             <key>Processor</key>
-            <string>PathDeleter</string>
+            <string>PlistReader</string>
         </dict>
         <dict>
             <key>Arguments</key>
@@ -83,6 +78,18 @@
             </dict>
             <key>Processor</key>
             <string>PkgCopier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This PR builds off the work done in #200 but also makes the necessary munki recipe changes.

@wegotoeleven, the only difference here is that I don't include the `PathDeleter` processor in the pkg recipe, since for munki recipes we need to unpack the package in order to assess the presence and versioning of the TeamViewerHost app, rather than the PKG receipt, and doing this cleanup in the pkg recipe means we'd have to duplicate this step later.