### PR TITLE
TeamViewer Fixes and Improvements

### DIFF
--- a/TeamViewer/PBXZPayloadUnpacker.py
+++ b/TeamViewer/PBXZPayloadUnpacker.py
@@ -1,0 +1,134 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2013 Greg Neagle
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for PBXZPayloadUnpacker class"""
+
+import os
+import shutil
+import subprocess
+
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["PBXZPayloadUnpacker"]
+
+
+class PBXZPayloadUnpacker(Processor):
+    """Unpacks a package payload."""
+
+    input_variables = {
+        "pkg_payload_path": {
+            "required": True,
+            "description": (
+                "Path to a payload from an expanded flat package or "
+                "Archive.pax.gz in a bundle package."
+            ),
+        },
+        "destination_path": {"required": True, "description": "Destination directory."},
+        "purge_destination": {
+            "required": False,
+            "description": (
+                "Whether the contents of the destination directory will "
+                "be removed before unpacking."
+            ),
+        },
+    }
+    output_variables = {}
+    description = __doc__
+
+    def unpack_pkg_payload(self):
+        """Uses ditto or aa to unpack a package payload into destination_path"""
+        # Create the destination directory if needed.
+        if not os.path.exists(self.env["destination_path"]):
+            try:
+                os.makedirs(self.env["destination_path"])
+            except OSError as err:
+                raise ProcessorError(
+                    f"Can't create {self.env['destination_path']}: {err.strerror}"
+                )
+        elif self.env.get("purge_destination"):
+            for entry in os.listdir(self.env["destination_path"]):
+                path = os.path.join(self.env["destination_path"], entry)
+                try:
+                    if os.path.isdir(path) and not os.path.islink(path):
+                        shutil.rmtree(path)
+                    else:
+                        os.unlink(path)
+                except OSError as err:
+                    raise ProcessorError(f"Can't remove {path}: {err.strerror}")
+
+        # set an error string when ditto or aa fail
+        error = ""
+        try:
+            dittocmd = [
+                "/usr/bin/ditto",
+                "-x",
+                "-z",
+                self.env["pkg_payload_path"],
+                self.env["destination_path"],
+            ]
+            proc = subprocess.Popen(
+                dittocmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            (_, err_out) = proc.communicate()
+        except OSError as err:
+            error = (
+                f"ditto execution failed with error code {err.errno}: {err.strerror}"
+            )
+        if proc.returncode != 0:
+            error = (
+                f"extraction of {self.env['pkg_payload_path']} with ditto failed: "
+                f"{err_out}"
+            )
+        if error and os.path.exists("/usr/bin/aa"):
+            try:
+                unpack_cmd = [
+                    "/usr/bin/aa",
+                    "extract",
+                    "-i",
+                    self.env["pkg_payload_path"],
+                    "-d",
+                    self.env["destination_path"],
+                ]
+                proc = subprocess.Popen(
+                    unpack_cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                proc.communicate()
+                # clear the error
+                error = ""
+            except OSError as err:
+                error = (
+                    f"aa execution failed with error code {err.errno}: {err.strerror}"
+                )
+            if proc.returncode != 0:
+                error = f"extraction of {self.env['pkg_payload_path']} with aa failed"
+
+        if error:
+            # show the error string
+            raise ProcessorError(error)
+
+        self.output(
+            f"Unpacked {self.env['pkg_payload_path']} to {self.env['destination_path']}"
+        )
+
+    def main(self):
+        self.unpack_pkg_payload()
+
+
+if __name__ == "__main__":
+    PROCESSOR = PBXZPayloadUnpacker()
+    PROCESSOR.execute_shell()

--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -36,9 +36,10 @@
 			<true/>
 			<key>unattended_uninstall</key>
 			<true/>
-      <key>postuninstall_script</key>
-      <string>#!/bin/bash
-rm -rf /Applications/TeamViewer.app</string>
+			<key>postuninstall_script</key>
+			<string>#!/bin/bash
+rm -rf /Applications/TeamViewer.app
+			</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>

--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -34,6 +34,24 @@
 			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
+			<key>preinstall_script</key>
+			<string>#!/bin/sh
+## preinstall script
+
+# Set TeamViewer to only restart the service
+# after installation, achieved by creating the
+# following file
+
+echo "1" > /tmp/tvonlystartservice
+			</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/sh
+## postinstall script
+
+# Clean the tmp file created at preinstall phase.
+
+sudo rm -rf /tmp/tvonlystartservice
+			</string>
 			<key>unattended_uninstall</key>
 			<true/>
 			<key>postuninstall_script</key>

--- a/TeamViewer/TeamViewer.pkg.recipe
+++ b/TeamViewer/TeamViewer.pkg.recipe
@@ -41,7 +41,7 @@
 		</dict>
 		<dict>
 			<key>Comment</key>
-			<string>TeamViewer 9 installs in /Applications/TeamViewer.app so extract accordingly</string>
+			<string>TeamViewer installs in /Applications/TeamViewer.app so extract accordingly</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_payload_path</key>
@@ -50,7 +50,7 @@
 				<string>%RECIPE_CACHE_DIR%/payload/root/Applications</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
+			<string>PBXZPayloadUnpacker</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>


### PR DESCRIPTION
This PR is targeted at issues #212 #220.

TeamViewer has recently made changes that mean the currently available `PkgPayloadUnpacker` does not support the Payload provided. A custom processor has been provided with the requisite changes to service the recipe until the original one is updated at which point the custom processor will become redundant and be removed.

Additionally, the changes to the Munki recipe ensure that TeamViewer does not start post-installation as detailed in the target issue.