### PR TITLE
Switch Kaleidoscope to v3 Sparkle feed

### DIFF
--- a/Kaleidoscope/Kaleidoscope.download.recipe
+++ b/Kaleidoscope/Kaleidoscope.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Kaleidoscope</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>https://updates.kaleidoscope.app/v2/prod/appcast</string>
+		<string>https://updates.kaleidoscope.app/v3/prod/appcast</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>


### PR DESCRIPTION
This is a super minor update to switch to the v3 Sparkle feed. As of right now, this downloads version 3.4.3, the latest. Thanks!