### PR TITLE
updated workflows for latest 1Password, added architecture selection

### DIFF
--- a/AgileBits/1Password.download.recipe
+++ b/AgileBits/1Password.download.recipe
@@ -3,28 +3,32 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of 1Password.</string>
+	<string>Downloads the current release version of 1Password.
+
+Valid PLATFORM_ARCH arguments are:
+- "latest-aarch64": Downloads .NET for Apple Silicon Macs
+- "latest": Downloads 1Password for Intel Macs (default)</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.1Password</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>1Password</string>
+		<key>PLATFORM_ARCH</key>
+		<string>latest</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.4</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://app-updates.agilebits.com/download/OPM7</string>
-				<key>filename</key>
-				<string>1Password.pkg</string>
+				<string>https://downloads.1password.com/mac/1Password-%PLATFORM_ARCH%.zip</string>
 			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>
@@ -32,56 +36,22 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_path</key>
-				<string>%pathname%</string>
 				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: AgileBits Inc. (2BUA8C4S2C)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-			<key>Arguments</key>
-			<dict>
-				<key>flat_pkg_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/1Password.pkg/Payload</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
+				<array/>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/1Password 7.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/1Password.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.agilebits.onepassword7" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2BUA8C4S2C")</string>
+				<string>identifier "com.1password.1password" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2BUA8C4S2C"</string>
 				<key>strict_verification</key>
-				<true />
-				<key>expected_authority_names</key>
-				<array>
-				</array>
+				<true/>
 			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/AgileBits/1Password.download.recipe
+++ b/AgileBits/1Password.download.recipe
@@ -6,7 +6,7 @@
 	<string>Downloads the current release version of 1Password.
 
 Valid PLATFORM_ARCH arguments are:
-- "latest-aarch64": Downloads .NET for Apple Silicon Macs
+- "latest-aarch64": Downloads 1Password for Apple Silicon Macs
 - "latest": Downloads 1Password for Intel Macs (default)</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.1Password</string>

--- a/AgileBits/1Password.download.recipe
+++ b/AgileBits/1Password.download.recipe
@@ -35,6 +35,11 @@ Valid PLATFORM_ARCH arguments are:
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>

--- a/AgileBits/1Password.pkg.recipe
+++ b/AgileBits/1Password.pkg.recipe
@@ -11,47 +11,33 @@
 		<key>NAME</key>
 		<string>1Password</string>
 	</dict>
-	<key>ParentRecipe</key>
-	<string>io.github.hjuutilainen.download.1Password</string>
 	<key>MinimumVersion</key>
 	<string>1.0.4</string>
+	<key>ParentRecipe</key>
+	<string>io.github.hjuutilainen.download.1Password</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Comment</key>
-			<string>Get version from the app</string>
-			<key>Processor</key>
-			<string>Versioner</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/1Password 7.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<string>%input_path%/Contents/Info.plist</string>
 			</dict>
+			<key>Comment</key>
+			<string>Get version from the app.</string>
+			<key>Processor</key>
+			<string>Versioner</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>PkgCopier</string>
 			<key>Arguments</key>
 			<dict>
-				<key>source_pkg</key>
-				<string>%pathname%</string>
+				<key>app_path</key>
+				<string>%input_path%</string>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%PLATFORM_ARCH%-%version%.pkg</string>
 			</dict>
-		</dict>
-		<dict>
 			<key>Processor</key>
-			<string>PathDeleter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/unpack</string>
-					<string>%RECIPE_CACHE_DIR%/Applications</string>
-				</array>
-			</dict>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
- updated to current 1Password URL #222
- added support for Intel/Apple Silicon download selection via `%PLATFORM_ARCH%` input variable (defaults to Intel)
- replaced .pkg unpacker steps with Unarchiver (app is now distributed in a zip)
- updated code signature requirement for current app version
- updated packaging workflow to account for changes in download recipe
- added platform architecture to .pkg file name
- linted files