### PR TITLE
fixed arch

### DIFF
--- a/HashiCorp/Vagrant.download.recipe
+++ b/HashiCorp/Vagrant.download.recipe
@@ -10,6 +10,10 @@
 	<dict>
 		<key>NAME</key>
 		<string>Vagrant</string>
+		<key>DOWNLOAD_ARCH</key>
+		<string>amd64</string>
+		<key>DOWNLOAD_OS</key>
+		<string>darwin</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -20,12 +24,12 @@
 			<string>HashiCorpURLProvider</string>
 			<key>Arguments</key>
 			<dict>
+				<key>arch</key>
+				<string>%DOWNLOAD_ARCH%</string>
+				<key>os</key>
+				<string>%DOWNLOAD_OS%</string>
 				<key>project_name</key>
 				<string>vagrant</string>
-				<key>os</key>
-				<string>darwin</string>
-				<key>arch</key>
-				<string>x86_64</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
- set `arch` to `amd64` by default ([changed as of Vagrant 2.3.0](https://releases.hashicorp.com/vagrant/2.3.0/))
- moved `arch` and `os` values to `DOWNLOAD_ARCH` and `DOWNLOAD_OS` input variables to allow overrides whenever Vagrant makes an Apple Silicon release