### PR TITLE
New HashiCorp Releases API values

### DIFF
--- a/HashiCorp/Vagrant.download.recipe
+++ b/HashiCorp/Vagrant.download.recipe
@@ -12,7 +12,8 @@
 		<string>Vagrant</string>
 		<key>arch</key>
 		<string>amd64</string>
-		<!-- <string>arm64</string> -->
+		<key>Comment</key>
+		<string>Currently HashiCorp only provides amd64, but possibly they'll provide arm64 at some point</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -37,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%arch%.dmg</string>
 			</dict>
 		</dict>
 		<dict>

--- a/HashiCorp/Vagrant.download.recipe
+++ b/HashiCorp/Vagrant.download.recipe
@@ -10,6 +10,9 @@
 	<dict>
 		<key>NAME</key>
 		<string>Vagrant</string>
+		<key>arch</key>
+		<string>amd64</string>
+		<!-- <string>arm64</string> -->
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -25,7 +28,7 @@
 				<key>os</key>
 				<string>darwin</string>
 				<key>arch</key>
-				<string>x86_64</string>
+				<string>%arch%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The HashiCorp Releases API now provides a new value for Darwin: `amd64` but it is likely they'll add `arm64` at some point.

Current API result

```
curl -sS https://api.releases.hashicorp.com/v1/releases/vagrant/latest | jq | grep darwin_
      "url": "https://releases.hashicorp.com/vagrant/2.3.0/vagrant_2.3.0_darwin_amd64.dmg"
```

Testing `amd64` with .download recipe

```
{'AUTOPKG_VERSION': '2.4.1',
 'CHECK_FILESIZE_ONLY': False,
 'Comment': "Currently HashiCorp only provides amd64, but possibly they'll "
            'provide arm64 at some point',
 'GIT_PATH': '/Library/Developer/CommandLineTools/usr/bin/git',
 'JSS_VERIFY_SSL': True,
 'MUNKI_REPO': '/Users/frank/git/munki',
 'NAME': 'Vagrant',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/frank/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Vagrant',
 'RECIPE_DIR': '/Users/frank/git/hjuutilainen-recipes/HashiCorp',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/frank/git/hjuutilainen-recipes/HashiCorp/Vagrant.download.recipe',
 'RECIPE_REPOS': {...},
 'RECIPE_SEARCH_DIRS': [...],
 'arch': 'amd64',
 'download_changed': True,
 'etag': '"d74deb67f1aa9f065416885282e512ff"',
 'expected_authority_names': ['Developer ID Installer: Hashicorp, Inc. '
                              '(D38WU7D763)',
                              'Developer ID Certification Authority',
                              'Apple Root CA'],
 'filename': 'Vagrant-amd64.dmg',
 'input_path': '/Users/frank/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Vagrant/downloads/Vagrant-amd64.dmg/vagrant.pkg',
 'last_modified': 'Tue, 09 Aug 2022 15:28:07 GMT',
 'os': 'darwin',
 'pathname': '/Users/frank/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Vagrant/downloads/Vagrant-amd64.dmg',
 'prefetch_filename': False,
 'project_name': 'vagrant',
 'url': 'https://releases.hashicorp.com/vagrant/2.3.0/vagrant_2.3.0_darwin_amd64.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/frank/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Vagrant/downloads/Vagrant-amd64.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': '2.3.0'}
 ```
 
