### PR TITLE
Arch value changed from x86_64 to amd64

### DIFF
--- a/HashiCorp/Vagrant.download.recipe
+++ b/HashiCorp/Vagrant.download.recipe
@@ -25,7 +25,7 @@
 				<key>os</key>
 				<string>darwin</string>
 				<key>arch</key>
-				<string>x86_64</string>
+				<string>amd64</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Arch value changed from x86_64 to amd64 like described on https://releases.hashicorp.com/vagrant/2.3.0/
For the previous versions (like https://releases.hashicorp.com/vagrant/2.2.0/) it's x86_64