### PR TITLE
Update GIMP.download.recipe to match current links

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>href='//download.gimp.org/gimp/v(.*)/osx/'</string>
+				<string>href="//download.gimp.org/gimp/v(.*)/osx/.*dmg"</string>
 				<key>url</key>
 				<string>https://www.gimp.org/downloads/</string>
 				<key>result_output_var_name</key>
@@ -34,9 +34,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>&gt;(gimp-[\d\.]+-x86_64(-\d)?\.dmg)&lt;</string>
+				<string>href="//download.gimp.org/gimp/v%version_match%/osx/(gimp-.*dmg)"</string>
 				<key>url</key>
-				<string>https://download.gimp.org/pub/gimp/v%version_match%/osx/?C=N;O=D</string>
+				<string>https://www.gimp.org/downloads/</string>
 				<key>result_output_var_name</key>
 				<string>dmg_match</string>
 			</dict>
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://download.gimp.org/pub/gimp/v%version_match%/osx/%dmg_match%</string>
+				<string>https://download.gimp.org/gimp/v%version_match%/osx/%dmg_match%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Fixes #236

Could be simplified, decided to do as few changes as possible however

Example run:

```
autopkg  run --ignore-parent-trust-verification-errors  -v GIMP.munki.recipe 


Processing GIMP.munki.recipe...
URLTextSearcher
URLTextSearcher: Found matching text (version_match): 2.10
URLTextSearcher
URLTextSearcher: Found matching text (dmg_match): gimp-2.10.32-x86_64.dmg
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/admin/Library/AutoPkg/Cache/local.munki.GIMP/downloads/GIMP.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/local.munki.GIMP/downloads/GIMP.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.iF1QrS/GIMP-2.10.app' matched from globbed '/private/tmp/dmg.iF1QrS/GIMP*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.iF1QrS/GIMP-2.10.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.iF1QrS/GIMP-2.10.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.iF1QrS/GIMP-2.10.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /mnt/munkipkgs/
MunkiImporter: Item GIMP.dmg already exists in the munki repo as pkgs/apps/GIMP/GIMP-2.10.32.dmg.
Receipt written to /Users/admin/Library/AutoPkg/Cache/local.munki.GIMP/receipts/GIMP.munki-receipt-20220830-161851.plist

Nothing downloaded, packaged or imported.
```