### PR TITLE
Changed Fork to download using Sparkle feed

### DIFF
--- a/Fork/Fork.download.recipe
+++ b/Fork/Fork.download.recipe
@@ -10,20 +10,27 @@
 	<dict>
 		<key>NAME</key>
 		<string>Fork</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://git-fork.com/update/files/Fork.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>appcast_url</key>
+				<string>https://git-fork.com/update/feed.xml</string>
+			</dict>
+			<key>Processor</key>
+			<string>SparkleUpdateInfoProvider</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The fixed download URL specified in the current download recipe is stuck at downloading version 2.11.3 of Fork. I found that Fork is available via a Sparkle feed so have updated the download recipe to use this and get the current version. I have tested updated download recipe with the other child recipes (pkg, munki & install) and these all work as expected with this change.