### PR TITLE
Add mulit-arch support for GIMP

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -1,74 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Downloads the latest version of GIMP from gimp.org.</string>
-	<key>Identifier</key>
-	<string>io.github.hjuutilainen.download.GIMP</string>
-	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>GIMP</string>
+		<key>Description</key>
+		<string>Downloads the latest version of GIMP from gimp.org.
+
+This recipe supports two architecture values:
+	- x86_64
+	- arm64</string>
+		<key>Identifier</key>
+		<string>io.github.hjuutilainen.download.GIMP</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>GIMP</string>
+			<key>ARCH</key>
+			<string>x86_64</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>1.0.4</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>URLTextSearcher</string>
+				<key>Arguments</key>
+				<dict>
+					<key>re_pattern</key>
+					<string>//download\.gimp\.org/gimp/v[0-9\.]*/macos/gimp-[0-9\.\-]*-%ARCH%\.dmg</string>
+					<key>url</key>
+					<string>https://www.gimp.org/downloads/</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+				<key>Arguments</key>
+				<dict>
+					<key>url</key>
+					<string>https:%match%</string>
+					<key>filename</key>
+					<string>%NAME%.dmg</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+				<key>Arguments</key>
+				<dict>
+					<key>input_path</key>
+					<string>%pathname%/GIMP*.app</string>
+					<key>requirement</key>
+					<string>identifier "org.gimp.gimp-2.10:" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T25BQ8HSJF</string>
+					<key>strict_verification</key>
+					<true />
+				</dict>
+			</dict>
+		</array>
 	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.4</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>href='//download.gimp.org/gimp/v(.*)/osx/'</string>
-				<key>url</key>
-				<string>https://www.gimp.org/downloads/</string>
-				<key>result_output_var_name</key>
-				<string>version_match</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>&gt;(gimp-[\d\.]+-x86_64(-\d)?\.dmg)&lt;</string>
-				<key>url</key>
-				<string>https://download.gimp.org/pub/gimp/v%version_match%/osx/?C=M&amp;O=D</string>
-				<key>result_output_var_name</key>
-				<string>dmg_match</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://download.gimp.org/pub/gimp/v%version_match%/osx/%dmg_match%</string>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/GIMP*.app</string>
-				<key>requirement</key>
-				<string>identifier "org.gimp.gimp-2.10:" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T25BQ8HSJF</string>
-				<key>strict_verification</key>
-				<true />
-			</dict>
-		</dict>
-	</array>
-</dict>
 </plist>

--- a/GIMP/GIMP.munki.recipe
+++ b/GIMP/GIMP.munki.recipe
@@ -1,63 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Downloads the latest version of GIMP from gimp.org and imports into Munki.</string>
-	<key>Identifier</key>
-	<string>io.github.hjuutilainen.munki.GIMP</string>
-	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>GIMP</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/GIMP</string>
-		<key>MUNKI_CATEGORY</key>
-		<string>Image Manipulation</string>
-		<key>pkginfo</key>
+		<key>Description</key>
+		<string>Downloads the latest version of GIMP from gimp.org and imports into Munki.
+
+This recipe supports two architecture values:
+	- x86_64
+	- arm64</string>
+		<key>Identifier</key>
+		<string>io.github.hjuutilainen.munki.GIMP</string>
+		<key>Input</key>
 		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>category</key>
-			<string>%MUNKI_CATEGORY%</string>
-			<key>description</key>
-			<string>GIMP is the GNU Image Manipulation Program. It is a freely distributed piece of software for such tasks as photo retouching, image composition and image authoring. It works on many operating systems, in many languages.</string>
-			<key>developer</key>
-			<string>The GIMP Team</string>
-			<key>display_name</key>
+			<key>NAME</key>
 			<string>GIMP</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-			<key>unattended_uninstall</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.4</string>
-	<key>ParentRecipe</key>
-	<string>io.github.hjuutilainen.download.GIMP</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
+			<key>ARCH</key>
+			<string>x86_64</string>
+			<key>MUNKI_REPO_SUBDIR</key>
+			<string>apps/GIMP</string>
+			<key>MUNKI_CATEGORY</key>
+			<string>Image Manipulation</string>
+			<key>pkginfo</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%pathname%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>additional_makepkginfo_options</key>
+				<key>catalogs</key>
 				<array>
-					<string>--destinationitemname</string>
-					<string>%NAME%.app</string>
+					<string>testing</string>
+				</array>
+				<key>category</key>
+				<string>%MUNKI_CATEGORY%</string>
+				<key>description</key>
+				<string>GIMP is the GNU Image Manipulation Program. It is a freely distributed piece of software for such tasks as photo retouching, image composition and image authoring. It works on many operating systems, in many languages.</string>
+				<key>developer</key>
+				<string>The GIMP Team</string>
+				<key>display_name</key>
+				<string>GIMP</string>
+				<key>name</key>
+				<string>%NAME%</string>
+				<key>unattended_install</key>
+				<true />
+				<key>unattended_uninstall</key>
+				<true />
+				<key>supported_architectures</key>
+				<array>
+					<string>%ARCH%</string>
 				</array>
 			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
 		</dict>
-	</array>
-</dict>
+		<key>MinimumVersion</key>
+		<string>1.0.4</string>
+		<key>ParentRecipe</key>
+		<string>io.github.hjuutilainen.download.GIMP</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%pathname%</string>
+					<key>repo_subdirectory</key>
+					<string>%MUNKI_REPO_SUBDIR%</string>
+					<key>additional_makepkginfo_options</key>
+					<array>
+						<string>--destinationitemname</string>
+						<string>%NAME%.app</string>
+					</array>
+				</dict>
+				<key>Processor</key>
+				<string>MunkiImporter</string>
+			</dict>
+		</array>
+	</dict>
 </plist>


### PR DESCRIPTION
I added the option for multi-arch (x86_64 and arm64) via variable input with default being x86_64. This does not break existing overwrites. 

I also removed one instance to URLTextSearcher as it was not required.


Here is a sample output for x86_64:

<details>
  <summary><b>Sample output x86_64</b></summary>
<pre><code>autopkg run /Users/trujmu/Library/CloudStorage/OneDrive-TrustedShopsGmbH/Repositories/hjuutilainen-recipes/GIMP/GIMP.munki.recipe -vv -k MUNKI_REPO=/Users/trujmu/Desktop -k DISABLE_CODE_SIGNATURE_VERIFICATION=true
Processing /Users/trujmu/Library/CloudStorage/OneDrive-TrustedShopsGmbH/Repositories/hjuutilainen-recipes/GIMP/GIMP.munki.recipe...
WARNING: /Users/trujmu/Library/CloudStorage/OneDrive-TrustedShopsGmbH/Repositories/hjuutilainen-recipes/GIMP/GIMP.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '//download\\.gimp\\.org/gimp/v[0-9\\.]*/macos/gimp-[0-9\\.\\-]*-x86_64\\.dmg',
           'url': 'https://www.gimp.org/downloads/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): //download.gimp.org/gimp/v2.10/macos/gimp-2.10.32-1-x86_64.dmg
{'Output': {'match': '//download.gimp.org/gimp/v2.10/macos/gimp-2.10.32-1-x86_64.dmg'}}
URLDownloader
{'Input': {'filename': 'GIMP.dmg',
           'url': 'https://download.gimp.org/gimp/v2.10/macos/gimp-2.10.32-1-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/trujmu/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GIMP/downloads/GIMP.dmg
{'Output': {'pathname': '/Users/trujmu/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GIMP/downloads/GIMP.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'DISABLE_CODE_SIGNATURE_VERIFICATION': 'true',
           'input_path': '/Users/trujmu/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GIMP/downloads/GIMP.dmg/GIMP*.app',
           'requirement': 'identifier "org.gimp.gimp-2.10:" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'T25BQ8HSJF',
           'strict_verification': True}}
CodeSignatureVerifier: Code signature verification disabled for this recipe run.
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/trujmu/Desktop',
           'additional_makepkginfo_options': ['--destinationitemname',
                                              'GIMP.app'],
           'pkg_path': '/Users/trujmu/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GIMP/downloads/GIMP.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Image Manipulation',
                       'description': 'GIMP is the GNU Image Manipulation '
                                      'Program. It is a freely distributed '
                                      'piece of software for such tasks as '
                                      'photo retouching, image composition and '
                                      'image authoring. It works on many '
                                      'operating systems, in many languages.',
                       'developer': 'The GIMP Team',
                       'display_name': 'GIMP',
                       'name': 'GIMP',
                       'supported_architectures': ['x86_64'],
                       'unattended_install': True,
                       'unattended_uninstall': True},
           'repo_subdirectory': 'apps/GIMP'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/trujmu/Desktop
MunkiImporter: Copied pkginfo to: /Users/trujmu/Desktop/pkgsinfo/apps/GIMP/GIMP-2.10.32.plist
MunkiImporter:            pkg to: /Users/trujmu/Desktop/pkgs/apps/GIMP/GIMP-2.10.32.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'GIMP',
                                                       'pkg_repo_path': 'apps/GIMP/GIMP-2.10.32.dmg',
                                                       'pkginfo_path': 'apps/GIMP/GIMP-2.10.32.plist',
                                                       'version': '2.10.32'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'trujmu',
                                         'creation_date': datetime.datetime(2022, 12, 19, 7, 57, 24),
                                         'munki_version': '6.0.1.4523',
                                         'os_version': '13.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Image Manipulation',
                           'description': 'GIMP is the GNU Image Manipulation '
                                          'Program. It is a freely distributed '
                                          'piece of software for such tasks as '
                                          'photo retouching, image composition '
                                          'and image authoring. It works on '
                                          'many operating systems, in many '
                                          'languages.',
                           'developer': 'The GIMP Team',
                           'display_name': 'GIMP',
                           'installer_item_hash': '5669ca1f0ce63b0b7c2efd1ac1998116e5ea367b376d453f8341a5d28093f87f',
                           'installer_item_location': 'apps/GIMP/GIMP-2.10.32.dmg',
                           'installer_item_size': 259059,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.gimp.gimp-2.10',
                                         'CFBundleName': 'GIMP',
                                         'CFBundleShortVersionString': '2.10.32',
                                         'CFBundleVersion': '2.10.32',
                                         'minosversion': '10.12',
                                         'path': '/Applications/GIMP.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_item': 'GIMP.app',
                                              'destination_path': '/Applications',
                                              'source_item': 'GIMP.app'}],
                           'minimum_os_version': '10.12',
                           'name': 'GIMP',
                           'supported_architectures': ['x86_64'],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.10.32'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/trujmu/Desktop/pkgs/apps/GIMP/GIMP-2.10.32.dmg',
            'pkginfo_repo_path': '/Users/trujmu/Desktop/pkgsinfo/apps/GIMP/GIMP-2.10.32.plist'}}
Receipt written to /Users/trujmu/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GIMP/receipts/GIMP.munki-receipt-20221219-085724.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                  Pkg Repo Path               Icon Repo Path
    ----  -------  --------  ------------                  -------------               --------------
    GIMP  2.10.32  testing   apps/GIMP/GIMP-2.10.32.plist  apps/GIMP/GIMP-2.10.32.dmg
</pre></code>
</details>