### PR TITLE
Update iLokLicenseManager and Packages Munki Recipess

### DIFF
--- a/PACE Anti-Piracy/iLokLicenseManager.munki.recipe
+++ b/PACE Anti-Piracy/iLokLicenseManager.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of iLok License Manager and imports into Munki.</string>
+	<string>Downloads the current release version of iLok License Manager and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.munki.iLokLicenseManager</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>NAME</key>
 		<string>iLokLicenseManager</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -41,7 +45,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.3</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.iLokLicenseManager</string>
 	<key>Process</key>
@@ -109,6 +113,8 @@
 				</array>
 				<key>version_comparison_key</key>
 				<string>CFBundleVersion</string>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>

--- a/Packages/Packages.munki.recipe
+++ b/Packages/Packages.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of Packages and imports into Munki.</string>
+	<string>Downloads the current release version of Packages and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.munki.Packages</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>NAME</key>
 		<string>Packages</string>
 		<key>MUNKIIMPORT_PKG_NAME</key>
@@ -30,8 +34,6 @@
 			<string>Stéphane Sudre</string>
 			<key>display_name</key>
 			<string>Packages</string>
-			<key>minimum_os_version</key>
-			<string>10.5</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -75,7 +77,7 @@ exit 0
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Packages</string>
 	<key>Process</key>
@@ -124,6 +126,8 @@ exit 0
 					<string>/usr/local/bin/packagesbuild</string>
 					<string>/usr/local/bin/packagesutil</string>
 				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>

--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -28,8 +28,6 @@
 			<string>TeamViewer GmbH</string>
 			<key>display_name</key>
 			<string>TeamViewer</string>
-			<key>minimum_os_version</key>
-			<string>10.13.6</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -78,6 +76,32 @@ rm -rf /Applications/TeamViewer.app
 				</dict>
 			</dict>
 		</dict>
+		<dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/TeamViewer.app</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_ver</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+             <key>Arguments</key>
+             <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_ver%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Hi, @hjuutilainen 

The iLokLicenseManager and Packages Munki recipes currently don't set the `minimum_os_version` from the App's info.plist's, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.12 and 10.9 respectively

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/hjuutilainen-recipes/PACE\ Anti-Piracy/iLokLicenseManager.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/PACE Anti-Piracy/iLokLicenseManager.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/PACE Anti-Piracy/iLokLicenseManager.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 20 Dec 2022 20:11:21 GMT
URLDownloader: Storing new ETag header: "87cc6184e8fa8b8da88b5166f52234e0"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/downloads/iLokLicenseManager.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename iLokLicenseManager.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/downloads/iLokLicenseManager.zip to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/iLokLicenseManager
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/iLokLicenseManager/LicenseSupportInstallerMac_v5.6.5_b653401d.dmg' from globbed '/Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/iLokLicenseManager/*.dmg'
FileFinder: Basename match: 'LicenseSupportInstallerMac_v5.6.5_b653401d.dmg'
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/iLokLicenseManager/LicenseSupportInstallerMac_v5.6.5_b653401d.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "License Support.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-19 08:08:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PACE Anti-Piracy, Inc. (TFZ8226T6X)
CodeSignatureVerifier:        Expires: 2027-03-25 16:06:32 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CC C2 DC F8 A6 04 ED 3B 3B 8D 7A 8D 56 98 2B B0 C5 EA 2E D7 DE 7E 
CodeSignatureVerifier:            87 22 7F 35 2F 95 8D 44 66 8D
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/iLokLicenseManager/LicenseSupportInstallerMac_v5.6.5_b653401d.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.5RVNN4/License Support.pkg to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/unpack/Activation_Experience.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/payload
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/unpack/iLok_License_Manager.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/payload
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/unpack/License_Service.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/payload
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/iLok License Manager.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.12
MunkiInstallsItemsCreator: Created installs item for /Library/Frameworks/PACEEdenExperience.framework
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/licenseDaemon.app
MunkiInstallsItemsCreator: Minimum os version: 10.9, is lower than prior value of: 10.12... skipping...
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.paceap.eden.iLokLicenseManager', 'CFBundleName': 'iLok License Manager', 'CFBundleShortVersionString': '5.6.5 GM (b4785, b653401d)', 'CFBundleVersion': '4785', 'minosversion': '10.12', 'path': '/Applications/iLok License Manager.app', 'type': 'application', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleShortVersionString': '5.6.5 GM (b4785, b653401d)', 'CFBundleVersion': '5.6.5.4785', 'path': '/Library/Frameworks/PACEEdenExperience.framework', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleIdentifier': 'com.paceap.eden.licenseDaemon', 'CFBundleName': 'licenseDaemon', 'CFBundleShortVersionString': '5.6.5 GM (b4785, b653401d)', 'CFBundleVersion': '5.6.5.4785', 'minosversion': '10.9', 'path': '/Library/PrivilegedHelperTools/licenseDaemon.app', 'type': 'application', 'version_comparison_key': 'CFBundleVersion'}], 'minimum_os_version': '10.12'} into pkginfo
Versioner
Versioner: Found version 5.6.5.4785 in file /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/payload/Library/PrivilegedHelperTools/licenseDaemon.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '5.6.5.4785'} into pkginfo
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/payload
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/iLok/iLokLicenseManager-5.6.5.4785.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/iLok/LicenseSupportInstallerMac_v5.6.5_b653401d-5.6.5.4785.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/receipts/iLokLicenseManager.munki-receipt-20230106-140041.plist

The following new items were downloaded:
    Download Path                                                                                                       
    -------------                                                                                                       
    /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.iLokLicenseManager/downloads/iLokLicenseManager.zip  

The following new items were imported into Munki:
    Name                Version     Catalogs  Pkginfo Path                                   Pkg Repo Path                                                        Icon Repo Path  
    ----                -------     --------  ------------                                   -------------                                                        --------------  
    iLokLicenseManager  5.6.5.4785  testing   apps/iLok/iLokLicenseManager-5.6.5.4785.plist  apps/iLok/LicenseSupportInstallerMac_v5.6.5_b653401d-5.6.5.4785.dmg 
```
and 

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/hjuutilainen-recipes/Packages/Packages.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/Packages/Packages.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/Packages/Packages.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 07 Feb 2022 23:13:04 GMT
URLDownloader: Storing new ETag header: "1e6dc8083-80257a-6201a780"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/downloads/Packages.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/downloads/Packages.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Packages.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-02-07 23:06:24 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Stephane Sudre (NL5M9E394P)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            03 00 1A 26 EE 51 DC 33 BA 91 22 CC FE DB 99 AB 29 A1 E3 34 AE 21 
CodeSignatureVerifier:            73 2D B0 1F F7 A6 E1 C2 30 35
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/downloads/Packages.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.06qJCg/packages/Packages.pkg to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/unpack/Packages.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/payload
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Packages.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.9
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/packages_builder
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/packages_dispatcher
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Locators/JavaScript.plugin
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Locators/Standard.plugin
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/CPU.plugin
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/Files.plugin
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/JavaScript.plugin
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/OS.plugin
MunkiInstallsItemsCreator: Created installs item for /Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/RAM.plugin
MunkiInstallsItemsCreator: Created installs item for /usr/local/bin/packagesbuild
MunkiInstallsItemsCreator: Created installs item for /usr/local/bin/packagesutil
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'fr.whitebox.Packages', 'CFBundleName': 'Packages', 'CFBundleShortVersionString': '1.2.10', 'CFBundleVersion': '728', 'minosversion': '10.9', 'path': '/Applications/Packages.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}, {'md5checksum': '09e0f0e10062432726ff5937626f4133', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/packages_builder', 'type': 'file'}, {'md5checksum': '7bcb62681fbf806086711251a8ee4a74', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/packages_dispatcher', 'type': 'file'}, {'CFBundleVersion': '2', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Locators/JavaScript.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleVersion': '1', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Locators/Standard.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleVersion': '2', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/CPU.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleVersion': '2', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/Files.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleVersion': '2', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/JavaScript.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleVersion': '2', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/OS.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'CFBundleVersion': '2', 'path': '/Library/PrivilegedHelperTools/fr.whitebox.packages/Requirements/RAM.plugin', 'type': 'bundle', 'version_comparison_key': 'CFBundleVersion'}, {'md5checksum': 'c12e71618108410c4974f4616c713908', 'path': '/usr/local/bin/packagesbuild', 'type': 'file'}, {'md5checksum': 'ba8cd0b1e997c33a71fccebe2ad6aa51', 'path': '/usr/local/bin/packagesutil', 'type': 'file'}], 'minimum_os_version': '10.9'} into pkginfo
Versioner
Versioner: Found version 1.2.10 in file /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/payload/Applications/Packages.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '1.2.10'} into pkginfo
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/payload
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Packages/Packages-1.2.10.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Packages/Packages-1.2.10.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/receipts/Packages.munki-receipt-20230106-141653.plist

The following new items were downloaded:
    Download Path                                                                                   
    -------------                                                                                   
    /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.Packages/downloads/Packages.dmg  

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                         Pkg Repo Path                      Icon Repo Path  
    ----      -------  --------  ------------                         -------------                      --------------  
    Packages  1.2.10   testing   apps/Packages/Packages-1.2.10.plist  apps/Packages/Packages-1.2.10.dmg 
```