### PR TITLE
Update TeamViewer and TeamViewerHost

### DIFF
--- a/TeamViewer/TeamViewer.munki.recipe
+++ b/TeamViewer/TeamViewer.munki.recipe
@@ -77,32 +77,6 @@ rm -rf /Applications/TeamViewer.app
 			</dict>
 		</dict>
 		<dict>
-            <key>Arguments</key>
-            <dict>
-                <key>info_path</key>
-                <string>%RECIPE_CACHE_DIR%/Applications/TeamViewer.app</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>LSMinimumSystemVersion</key>
-                    <string>min_os_ver</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>PlistReader</string>
-        </dict>
-        <dict>
-             <key>Arguments</key>
-             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>minimum_os_version</key>
-                    <string>%min_os_ver%</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>

--- a/TeamViewer/TeamViewer.pkg.recipe
+++ b/TeamViewer/TeamViewer.pkg.recipe
@@ -3,16 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of TeamViewer and extracts the app information.</string>
+	<string>Downloads the current release version of TeamViewer and extracts the app information.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.pkg.TeamViewer</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>NAME</key>
 		<string>TeamViewer</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.TeamViewer</string>
 	<key>Process</key>
@@ -61,6 +65,8 @@
 				<array>
 					<string>/Applications/TeamViewer.app</string>
 				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>

--- a/TeamViewer/TeamViewerHost.munki.recipe
+++ b/TeamViewer/TeamViewerHost.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of TeamViewerHost and imports into Munki.</string>
+    <string>Downloads the current release version of TeamViewerHost and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>io.github.hjuutilainen.munki.TeamViewerHost</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_CATEGORY</key>
         <string>Internet</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -37,7 +41,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>io.github.hjuutilainen.pkg.TeamViewerHost</string>
     <key>Process</key>
@@ -53,6 +57,8 @@
                 <array>
                     <string>/Applications/TeamViewerHost.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @hjuutilainen 

This PR fixes the erroneously committed code to the TeamViewer.munki.recipe here https://github.com/autopkg/hjuutilainen-recipes/commit/c3cb26895d2cd2845171234d3a28aff1ab56974c#diff-cbdf25c0748023c8010691a70462334f4955988761740f2d292ce96e5d296f5c (Sorry about that!)

The TeamViewer.pkg recipe and the TeamViewerHost.munki recipes currently don't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.14.6

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/hjuutilainen-recipes/TeamViewer/TeamViewer.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/TeamViewer/TeamViewer.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/TeamViewer/TeamViewer.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/downloads/TeamViewer.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/downloads/TeamViewer.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install TeamViewer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-12 11:46:47 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: TeamViewer Germany GmbH (H7UGFBUGV6)
CodeSignatureVerifier:        Expires: 2027-02-09 12:21:10 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            40 B7 9F BC F7 67 55 CC F9 B2 DA A7 1E EA B9 22 13 DF E5 E3 34 74 
CodeSignatureVerifier:            36 8C B0 13 CF 14 C5 FA F2 A2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/downloads/TeamViewer.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.jZ72sX/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/unpack
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/payload/root/Applications
PBXZPayloadUnpacker
PBXZPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/unpack/TeamViewerApp.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/payload/root/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/TeamViewer.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.14.6
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.teamviewer.TeamViewer', 'CFBundleName': 'TeamViewer', 'CFBundleShortVersionString': '15.37.3', 'CFBundleVersion': '1', 'minosversion': '10.14.6', 'path': '/Applications/TeamViewer.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.14.6'} into pkginfo
PlistReader
PlistReader: Reading: /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/payload/root/Applications/TeamViewer.app/Contents/Info.plist
PlistReader: Assigning value of '15.37.3' to output variable 'version'
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/payload
PkgCopier
PkgCopier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/downloads/TeamViewer.dmg
PkgCopier: Copied /private/tmp/dmg.pEWf1t/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/TeamViewer-15.37.3.pkg
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '15.37.3'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/TeamViewer/TeamViewer-15.37.3__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/TeamViewer/TeamViewer-15.37.3__1.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/receipts/TeamViewer.munki-receipt-20230106-145232.plist

The following packages were copied:
    Pkg Path                                                                                          
    --------                                                                                          
    /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewer/TeamViewer-15.37.3.pkg  

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                                 Pkg Repo Path                              Icon Repo Path  
    ----        -------  --------  ------------                                 -------------                              --------------  
    TeamViewer  15.37.3  testing   apps/TeamViewer/TeamViewer-15.37.3__1.plist  apps/TeamViewer/TeamViewer-15.37.3__1.pkg  
```
and 

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/hjuutilainen-recipes/TeamViewer/TeamViewerHost.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/TeamViewer/TeamViewerHost.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/hjuutilainen-recipes/TeamViewer/TeamViewerHost.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 15 Dec 2022 07:18:08 GMT
URLDownloader: Storing new ETag header: "639aca30-36348ac"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/downloads/TeamViewerHost.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/downloads/TeamViewerHost.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install TeamViewerHost.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-12 11:46:20 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: TeamViewer Germany GmbH (H7UGFBUGV6)
CodeSignatureVerifier:        Expires: 2027-02-09 12:21:10 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            40 B7 9F BC F7 67 55 CC F9 B2 DA A7 1E EA B9 22 13 DF E5 E3 34 74 
CodeSignatureVerifier:            36 8C B0 13 CF 14 C5 FA F2 A2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/downloads/TeamViewerHost.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.Z2wta2/Install TeamViewerHost.app/Contents/Resources/Install TeamViewerHost.pkg to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/unpack
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/payload/root/Applications
PBXZPayloadUnpacker
PBXZPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/unpack/TeamViewerHostApp.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/payload/root/Applications
PlistReader
PlistReader: Reading: /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/payload/root/Applications/TeamViewerHost.app/Contents/Info.plist
PlistReader: Assigning value of '15.37.3' to output variable 'version'
PlistReader: Assigning value of '10.14.6' to output variable 'min_os_version'
PkgCopier
PkgCopier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/downloads/TeamViewerHost.dmg
PkgCopier: Copied /private/tmp/dmg.LBaaKB/Install TeamViewerHost.app/Contents/Resources/Install TeamViewerHost.pkg to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/TeamViewerHost-15.37.3.pkg
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/TeamViewerHost.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.14.6
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.teamviewer.TeamViewerHost', 'CFBundleName': 'TeamViewerHost', 'CFBundleShortVersionString': '15.37.3', 'CFBundleVersion': '1', 'minosversion': '10.14.6', 'path': '/Applications/TeamViewerHost.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.14.6'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/teamviewer/TeamViewerHost-15.37.3.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/teamviewer/TeamViewerHost-15.37.3.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/payload
Receipt written to /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/receipts/TeamViewerHost.munki-receipt-20230106-145333.plist

The following new items were downloaded:
    Download Path                                                                                               
    -------------                                                                                               
    /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/downloads/TeamViewerHost.dmg  

The following packages were copied:
    Pkg Path                                                                                                  
    --------                                                                                                  
    /Users/paul/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.TeamViewerHost/TeamViewerHost-15.37.3.pkg  

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                  Pkg Repo Path                               Icon Repo Path  
    ----            -------  --------  ------------                                  -------------                               --------------  
    TeamViewerHost  15.37.3  testing   apps/teamviewer/TeamViewerHost-15.37.3.plist  apps/teamviewer/TeamViewerHost-15.37.3.pkg 
```