### PR TITLE
Fixes for strange LibreOffice download path, allows handling arm and x86_64

### DIFF
--- a/LibreOffice/CreateLibreOfficeAuxArchName.py
+++ b/LibreOffice/CreateLibreOfficeAuxArchName.py
@@ -1,0 +1,32 @@
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["CreateLibreOfficeAuxArchName"]
+
+
+class CreateLibreOfficeAuxArchName(Processor):
+    """This processor provides the extra architecture name needed for LibreOffice download paths for x86_64."""
+	
+    input_variables = {
+        "arch_name": {
+            "required": True,
+            "description": "The name of the architecture used in the source DMG and the output PKG.",
+        }
+    }
+    output_variables = {
+        "aux_arch_name": {"description": "The second form of architecture name used in the download path for x86_64.",}
+    }
+
+    description = __doc__
+
+    def main(self):
+        if ( self.env["arch_name"] ==  'aarch64'):
+            # this architecture name is used consistently
+            self.env["aux_arch_name"] = 'aarch64'
+        elif ( self.env["arch_name"] == 'x86_64' ):
+            # for x86_64 they use both forms in the path :(
+            self.env["aux_arch_name"] = 'x86-64'
+        else:
+            self.env["aux_arch_name"] = 'Architecture_' + arch_name + '_not_supported_by_CreateLibreOfficeAuxArchName.'
+if __name__ == "__main__":
+    PROCESSOR = CreateLibreOfficeAuxArchName()
+    PROCESSOR.execute_shell()

--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -6,7 +6,9 @@
 	<string>Downloads the latest LibreOffice. Set RELEASE to either "fresh" or "still".
 
 LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.
+The architecture (ARCH) can be 'x86-64' or 'aarch64'
+</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>
 	<key>Input</key>
@@ -15,11 +17,24 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
 		<string>fresh</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Comment</key>
+			<string>LibreOffice uses both x86_64 AND x86-64 in the download path. Here we build the x86-64 or aarch64 part.</string>
+			<key>Processor</key>
+			<string>CreateLibreOfficeAuxArchName</string>
+			<key>Arguments</key>
+			<dict>
+				<key>arch_name</key>
+				<string>%ARCH%</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Comment</key>
 			<string>Try to parse the the latest fresh or still version from current release notes</string>
@@ -47,9 +62,9 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://download.documentfoundation.org/libreoffice/stable/%version%/mac/x86_64/LibreOffice_%version%_MacOS_x86-64.dmg</string>
+				<string>https://download.documentfoundation.org/libreoffice/stable/%version%/mac/%ARCH%/LibreOffice_%version%_MacOS_%aux_arch_name%.dmg</string>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 		</dict>
 		<dict>

--- a/LibreOffice/LibreOffice.pkg.recipe
+++ b/LibreOffice/LibreOffice.pkg.recipe
@@ -15,6 +15,8 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
 		<string>fresh</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 	</dict>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>
@@ -64,7 +66,7 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 				<key>pkg_request</key>
 				<dict>
 					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
+					<string>%NAME%-%ARCH%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>


### PR DESCRIPTION
Hi,

LibreOffice uses x86_64 as well as x86-64 in the download path for the intel package. I have added an extra handler that can set the patch depending on the desired architecture.

I also add an architecture tag to the produced LibreOffice pkg name.

I would be grateful if you could merge these changes - or provide a better method of handling the archs. 