### PR TITLE
Remove minimum_os_version

### DIFF
--- a/AlfredApp/Alfred5.munki.recipe
+++ b/AlfredApp/Alfred5.munki.recipe
@@ -33,8 +33,6 @@
 			<string>Running with Crayons Ltd</string>
 			<key>display_name</key>
 			<string>Alfred 5</string>
-			<key>minimum_os_version</key>
-			<string>10.10</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
The minimum OS version for Alfred 5 has changed - if `minimum_os_version` is missing from the recipe, it looks like AutoPkg can determine that automatically instead.