### PR TITLE
Remove destinationitemname overwrite in GIMP recipe

### DIFF
--- a/GIMP/GIMP.munki.recipe
+++ b/GIMP/GIMP.munki.recipe
@@ -59,11 +59,6 @@ This recipe supports two architecture values:
 					<string>%pathname%</string>
 					<key>repo_subdirectory</key>
 					<string>%MUNKI_REPO_SUBDIR%</string>
-					<key>additional_makepkginfo_options</key>
-					<array>
-						<string>--destinationitemname</string>
-						<string>%NAME%.app</string>
-					</array>
 				</dict>
 				<key>Processor</key>
 				<string>MunkiImporter</string>


### PR DESCRIPTION
Hello @hjuutilainen 

would it be possible to remove the `additional_makepkginfo_options` from MunkiImporter's arguments?
I'd like to create separate overrides for arm64 and x86_64. I therefore changed (in my overrides) the NAME variable to GIMP-ARM and GIMP-Intel respectively, but this resulted in GIMP being installed and displayed to the user as GIMP-ARM / GIMP-Intel and not just as GIMP.