### PR TITLE
Update Kaleidoscope code signature requirement

### DIFF
--- a/Kaleidoscope/Kaleidoscope.download.recipe
+++ b/Kaleidoscope/Kaleidoscope.download.recipe
@@ -55,7 +55,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Kaleidoscope.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "app.kaleidoscope.v3" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4G35KLFD64")</string>
+				<string>anchor apple generic and identifier "app.kaleidoscope.v4" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4G35KLFD64")</string>
 				<key>strict_verification</key>
 				<true />
 			</dict>


### PR DESCRIPTION
Kaleidoscope's feed is now providing major version 4, which has a new bundle identifier.

Test output:

```
% autopkg run -vv './Kaleidoscope/Kaleidoscope.download.recipe'
Processing ~/Developer/repo-lasso/repos/autopkg/hjuutilainen-recipes/Kaleidoscope/Kaleidoscope.download.recipe...
WARNING: ~/Developer/repo-lasso/repos/autopkg/hjuutilainen-recipes/Kaleidoscope/Kaleidoscope.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://updates.kaleidoscope.app/v3/prod/appcast'}}
SparkleUpdateInfoProvider: Items in feed: 2
SparkleUpdateInfoProvider: Items in default channel: 2
SparkleUpdateInfoProvider: Version retrieved from appcast: 3824
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.0.3
SparkleUpdateInfoProvider: Found URL https://updates.kaleidoscope.app/v4/prod/Kaleidoscope-4.0.3-3824.app.zip
{'Output': {'url': 'https://updates.kaleidoscope.app/v4/prod/Kaleidoscope-4.0.3-3824.app.zip',
            'version': '4.0.3'}}
URLDownloader
{'Input': {'url': 'https://updates.kaleidoscope.app/v4/prod/Kaleidoscope-4.0.3-3824.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 02 Jun 2023 14:05:43 GMT
URLDownloader: Storing new ETag header: "8b55a41abd7847a00925c213569ad227"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/downloads/Kaleidoscope-4.0.3-3824.app.zip
{'Output': {'download_changed': True,
            'etag': '"8b55a41abd7847a00925c213569ad227"',
            'last_modified': 'Fri, 02 Jun 2023 14:05:43 GMT',
            'pathname': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/downloads/Kaleidoscope-4.0.3-3824.app.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/downloads/Kaleidoscope-4.0.3-3824.app.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/downloads/Kaleidoscope-4.0.3-3824.app.zip',
           'destination_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/Kaleidoscope',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Kaleidoscope-4.0.3-3824.app.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/downloads/Kaleidoscope-4.0.3-3824.app.zip to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/Kaleidoscope
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/Kaleidoscope/Kaleidoscope.app',
           'requirement': 'anchor apple generic and identifier '
                          '"app.kaleidoscope.v4" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "4G35KLFD64")',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/Kaleidoscope/Kaleidoscope.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/Kaleidoscope/Kaleidoscope.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/Kaleidoscope/Kaleidoscope.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/receipts/Kaleidoscope.download-receipt-20230605-062850.plist

The following new items were downloaded:
    Download Path                                                                                                               
    -------------                                                                                                               
    ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.Kaleidoscope/downloads/Kaleidoscope-4.0.3-3824.app.zip 
```