### PR TITLE
Update Blender.download.recipe

### DIFF
--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -40,7 +40,7 @@
 				<key>url</key>
 				<string>https://www.blender.org/download/release/%download_path%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https://.*/blender-(?P&lt;version&gt;[0-9a-zA-Z\.]+)-macos-%ARCHITECTURE%.dmg)</string>
+				<string>"(?P&lt;url&gt;https://.*/blender-(?P&lt;version&gt;[0-9a-zA-Z\.]+)-macos-%ARCHITECTURE%.dmg)"</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Addition of " to second URLTextSearcher pattern to avoid return of url like  'url': 'https://mirror.clarkson.edu/blender/release/Blender3.5/blender-3.5.1-macos-x64.dmg">https://mirror.clarkson.edu/blender/release/Blender3.5/blender-3.5.1',