### PR TITLE
Update TextExpander7.download.recipe

### DIFF
--- a/SmileOnMyMac/TextExpander7.download.recipe
+++ b/SmileOnMyMac/TextExpander7.download.recipe
@@ -21,7 +21,12 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://textexpander.com/cgi-bin/redirect.pl?cmd=download&amp;platform=osx</string>
+				<string>https://rest-prod.tenet.textexpander.com/download?platform=mac</string>
+				<key>request_headers</key>
+				<dict>
+					<key>user-agent</key>
+					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+				</dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
The existing URL in the recipe has stopped downloading the current version.

The download URL on the TextExpander website has been changed to this new URL. It requires `request_headers` to be passed.