### PR TITLE
Add the ability to have a preferred major version

### DIFF
--- a/Elasticsearch/elasticbeat.download.recipe
+++ b/Elasticsearch/elasticbeat.download.recipe
@@ -14,6 +14,8 @@
 		<string>filebeat</string>
 		<key>OPTIONAL_VERSION</key>
 		<string></string>
+		<key>PREFERRED_MAJOR_VERSION</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.4</string>
@@ -27,7 +29,7 @@
 				<key>url</key>
 				<string>https://www.elastic.co/downloads/beats/%BEAT_NAME%%OPTIONAL_VERSION%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https://artifacts.elastic.co/downloads/beats/%BEAT_NAME%/%BEAT_NAME%%OPTIONAL_VERSION%-(?P&lt;version&gt;[\d\.]+)-darwin-x86_64\.tar\.gz)</string>
+				<string>(?P&lt;url&gt;https://artifacts.elastic.co/downloads/beats/%BEAT_NAME%/%BEAT_NAME%%OPTIONAL_VERSION%-(?P&lt;version&gt;%PREFERRED_MAJOR_VERSION%[\d\.]+)-darwin-x86_64\.tar\.gz)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
We have been using the Elastic search recipe: [hjuutilainen-recipes ](https://github.com/autopkg/hjuutilainen-recipes/blob/master/Elasticsearch/filebeat.download.recipe) for filebeat oss, and once again elastic filebeat has released an update of 8.8.2, then a back port of `7.17.11` but the `URLTextSearcher` was finding the `7.17.11` version instead of the newer one `8.8.2` version because its choosing the first regex match that it finds. By adding a preferred major version variable I can choose between major version `8` or `7` if I want to grab the correct one for my needs. 
With an empty string (default) it will behave as it does now and find the last one published that meets the regex

[elastic_feedback_majorempty.txt](https://github.com/autopkg/hjuutilainen-recipes/files/12088798/elastic_feedback_majorempty.txt)
[elastic_feedback_withmajor.txt](https://github.com/autopkg/hjuutilainen-recipes/files/12088799/elastic_feedback_withmajor.txt)
