### PR TITLE
Update GIMP.download.recipe

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -41,6 +41,8 @@ This recipe supports two architecture values:
 					<string>https:%match%</string>
 					<key>filename</key>
 					<string>%NAME%.dmg</string>
+					<key>CHECK_FILESIZE_ONLY</key>
+					<true/>
 				</dict>
 			</dict>
 			<dict>


### PR DESCRIPTION
We noticed that this recipe keeps downloading (and importing) GIMP although the version has not changed. What caused this is that the server that hosts GIMP, keeps giving different e-tags every download.

We fixed this by adding:

<key>CHECK_FILESIZE_ONLY</key>
<true/>

to URLDownloader processor, so the recipe will try to match the files via size, not e-tags.