### PR TITLE
Changes Due to Package Path on DMG Changing

### DIFF
--- a/Packages/Packages.download.recipe
+++ b/Packages/Packages.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/packages/Packages.pkg</string>
+				<string>%pathname%/Install Packages.pkg</string>
 				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Stephane Sudre (NL5M9E394P)</string>

--- a/Packages/Packages.munki.recipe
+++ b/Packages/Packages.munki.recipe
@@ -15,7 +15,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 		<key>NAME</key>
 		<string>Packages</string>
 		<key>MUNKIIMPORT_PKG_NAME</key>
-		<string>packages/Packages.pkg</string>
+		<string>Install Packages.pkg</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/Packages</string>
 		<key>MUNKI_CATEGORY</key>
@@ -86,7 +86,7 @@ exit 0
 			<key>Arguments</key>
 			<dict>
 				<key>flat_pkg_path</key>
-				<string>%pathname%/packages/*.pkg</string>
+				<string>%pathname%/*.pkg</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 			</dict>

--- a/Packages/Packages.pkg.recipe
+++ b/Packages/Packages.pkg.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_pkg</key>
-				<string>%pathname%/packages/Packages.pkg</string>
+				<string>%pathname%/Install Packages.pkg</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
 			</dict>


### PR DESCRIPTION
The path to the installation package changed from `<dmg>/packages/Packages.pkg` to `<dmg>/Install Packages.pkg`.  These changes are to support the path change.