### PR TITLE
Update WorkspaceONEIntelligentHub.munki.recipe

### DIFF
--- a/VMware/WorkspaceONEIntelligentHub.munki.recipe
+++ b/VMware/WorkspaceONEIntelligentHub.munki.recipe
@@ -30,8 +30,6 @@
 			<string>%MUNKI_DEVELOPER%</string>
 			<key>display_name</key>
 			<string>Workspace ONE Intelligent Hub</string>
-			<key>minimum_os_version</key>
-			<string>10.11</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -41,7 +39,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.4</string>
+	<string>2.7.0</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.WorkspaceONEIntelligentHub</string>
 	<key>Process</key>
@@ -71,6 +69,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>derive_minimum_os_version</key>
+				<string>true</string>
 				<key>faux_root</key>
 				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>installs_item_paths</key>


### PR DESCRIPTION
This removes the hard-coded `minimum_os_version` (which has significantly changed over the years) and determines it automatically each run.