### PR TITLE
Updated regex and %RELEASE% variable for Libre Office

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest LibreOffice. Set RELEASE to either "fresh" or "still".
+	<string>Downloads the latest LibreOffice. Set RELEASE to either 'Latest' or 'Previous'.
 
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.
+LibreOffice Previous is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
+LibreOffice Latest is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our Latest version.
 The architecture (ARCH) can be 'x86-64' or 'aarch64'
 </string>
 	<key>Identifier</key>
@@ -16,7 +16,7 @@ The architecture (ARCH) can be 'x86-64' or 'aarch64'
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>fresh</string>
+		<string>Latest</string>
 		<key>ARCH</key>
 		<string>x86_64</string>
 	</dict>
@@ -37,13 +37,13 @@ The architecture (ARCH) can be 'x86-64' or 'aarch64'
 		</dict>
 		<dict>
 			<key>Comment</key>
-			<string>Try to parse the the latest fresh or still version from current release notes</string>
+			<string>Try to parse the the 'Latest' or 'Previous' version from current release notes</string>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>LibreOffice (?P&lt;version&gt;[\d\.]+) \([\d-]+\) - (?i)%RELEASE% Branch</string>
+				<string>LibreOffice (?P&lt;version&gt;\d+\.\d+(\.\d+)?) \(\d{4}-\d{2}-\d{2}\) - %RELEASE% Release</string>
 				<key>url</key>
 				<string>https://www.libreoffice.org/download/release-notes/</string>
 			</dict>

--- a/LibreOffice/LibreOffice.install.recipe
+++ b/LibreOffice/LibreOffice.install.recipe
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Installs the current release version of LibreOffice. Set RELEASE to either "fresh" or "still".
+	<string>Installs the latest version of LibreOffice. Set RELEASE to either 'Latest' or 'Previous'.
 
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+LibreOffice Previous is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
+LibreOffice Latest is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our Latest version.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.install.LibreOffice</string>
 	<key>Input</key>
@@ -14,7 +14,7 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>fresh</string>
+		<string>Latest</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>

--- a/LibreOffice/LibreOffice.munki.recipe
+++ b/LibreOffice/LibreOffice.munki.recipe
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of LibreOffice and imports into Munki. Set RELEASE to either "fresh" or "still".
+	<string>Downloads the latest version of LibreOffice and imports into Munki. Set RELEASE to either 'Latest' or 'Previous'.
 
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+LibreOffice Previous is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
+LibreOffice Latest is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our Latest version.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.munki.LibreOffice</string>
 	<key>Input</key>
@@ -14,7 +14,7 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>fresh</string>
+		<string>Latest</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/LibreOffice</string>
 		<key>MUNKI_CATEGORY</key>

--- a/LibreOffice/LibreOffice.pkg.recipe
+++ b/LibreOffice/LibreOffice.pkg.recipe
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of LibreOffice and builds a package. Set RELEASE to either "fresh" or "still".
+	<string>Downloads the latest version of LibreOffice and builds a package. Set RELEASE to either 'Latest' or 'Previous'.
 
-LibreOffice Still is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
-LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
+LibreOffice Previous is the stable version that has undergone more testing (over a longer time). It is usually recommended for more conservative use.
+LibreOffice Latest is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our Latest version.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.pkg.LibreOffice</string>
 	<key>Input</key>
@@ -14,7 +14,7 @@ LibreOffice Fresh is the stable version with the most recent features. Users int
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>fresh</string>
+		<string>Latest</string>
 		<key>ARCH</key>
 		<string>x86_64</string>
 	</dict>


### PR DESCRIPTION
Regex and %RELEASE% variable should now reflect the new naming convention on the releases page. You must use 'Latest' instead of 'fresh' and 'Previous' instead of 'still'.

On a side note, there is a version mismatch on the releases page and the download URL at the moment.

On the releases page it says "24.2". 
https://www.libreoffice.org/download/release-notes/

The download URL is "24.2.0". 
https://www.libreoffice.org/donate/dl/mac-aarch64/24.2.0/en-GB/LibreOffice_24.2.0_MacOS_aarch64.dmg

This makes the recipe unable to download the "24.2.0" version for "Latest". I have emailed Libre Office to fix this. Until then the "Previous" version works as intended.