### PR TITLE
Update ATLAS.ti.download.recipe

### DIFF
--- a/ATLAS.ti/ATLAS.ti.download.recipe
+++ b/ATLAS.ti/ATLAS.ti.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>ATLAS.ti</string>
 		<key>APPCAST_URL</key>
-		<string>https://cdn.atlasti.com/mac.v23/sparklefeed_23.xml</string>
+		<string>https://releases.atlasti.com/mac/sparklefeed.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
The old sparkle feed url only had versions up to 23.3 - that has not been updated since October.

The updated sparkle feed url has all the latest realeases of Atlas TI : https://releases.atlasti.com/mac/sparklefeed.xml

I would replace the old sparkle feed url with a new one. Did this to our overrides already and works like a charm.