### PR TITLE
Update 1Password8.munki.recipe

### DIFF
--- a/AgileBits/1Password8.munki.recipe
+++ b/AgileBits/1Password8.munki.recipe
@@ -43,8 +43,12 @@
 
 # Remove version 7 remnants if they exist
 
-if [[ -e "/Applications/1Password 7.app.zip" ]]; then
+if [[ -e "/Applications/1Password 7.zip" ]]; then
     /bin/rm -f "/Applications/1Password 7.zip"
+fi
+
+if [[ -e "/Applications/1Password 7.app.zip" ]]; then
+    /bin/rm -f "/Applications/1Password 7.app.zip"
 fi
 
 if [[ -e "/Applications/1Password 7.app" ]]; then

--- a/AgileBits/1Password8.munki.recipe
+++ b/AgileBits/1Password8.munki.recipe
@@ -44,7 +44,7 @@
 # Remove version 7 remnants if they exist
 
 if [[ -e "/Applications/1Password 7.app.zip" ]]; then
-    /bin/rm -f "/Applications/1Password 7.app.zip"
+    /bin/rm -f "/Applications/1Password 7.zip"
 fi
 
 if [[ -e "/Applications/1Password 7.app" ]]; then


### PR DESCRIPTION
Current archive creation method omits the .app in the zip filename, postinstall does not rm as desired.  This updates to match.