### PR TITLE
Update GIMP.download.recipe

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -27,7 +27,7 @@ This recipe supports two architecture values:
 				<key>Arguments</key>
 				<dict>
 					<key>re_pattern</key>
-					<string>//download\.gimp\.org/gimp/v[0-9\.]*/macos/gimp-[0-9\.\-]*-%ARCH%\.dmg</string>
+					<string>(//download\.gimp\.org/gimp/v[0-9\.]*/macos/gimp-[0-9\.\-]*-%ARCH%(-1)?\.dmg)</string>
 					<key>url</key>
 					<string>https://www.gimp.org/downloads/</string>
 				</dict>


### PR DESCRIPTION
Fixes to #283
Looks like their URL we look for is changed to `https://download.gimp.org/gimp/v2.10/macos/gimp-2.10.38-x86_64-1.dmg` from `https://download.gimp.org/gimp/v2.10/macos/gimp-2.10.38-x86_64.dmg` 
This change should capture both the original URL and the new one