### PR TITLE
Citrix Workspace: minimum_os_version, installs array

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -68,6 +68,28 @@
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>
 		</dict>
+        <dict>
+           <key>Arguments</key>
+           <dict>
+              <key>flat_pkg_path</key>
+              <string>%RECIPE_CACHE_DIR%/payload/Library/Application Support/CitrixPackage/com.citrix.apps.cwa.pkg</string>
+              <key>destination_path</key>
+              <string>%RECIPE_CACHE_DIR%/payload2</string>
+           </dict>
+           <key>Processor</key>
+           <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+           <key>Arguments</key>
+           <dict>
+              <key>pkg_payload_path</key>
+              <string>%RECIPE_CACHE_DIR%/payload2/com.citrix.ICAClientcwa.pkg/Payload</string>
+              <key>destination_path</key>
+              <string>%RECIPE_CACHE_DIR%/payload3</string>
+           </dict>
+           <key>Processor</key>
+           <string>PkgPayloadUnpacker</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -91,11 +113,13 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Applications/Citrix Workspace.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/payload3/Applications/Citrix Workspace.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>
 					<string>version</string>
+					<key>LSMinimumSystemVersion</key>
+					<string>minimum_os_version</string>
 				</dict>
 			</dict>
 			<key>Processor</key>
@@ -106,10 +130,21 @@
 			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
-					<key>minimum_os_version</key>
-					<string>10.15</string>
-					<key>version</key>
-					<string>%version%</string>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                    <key>installs</key>
+                    <array>
+                       <dict>
+                          <key>CFBundleShortVersionString</key>
+                          <string>%version%</string>
+                          <key>path</key>
+                          <string>/Applications/Citrix Workspace.app</string>
+                          <key>type</key>
+                          <string>application</string>
+                          <key>version_comparison_key</key>
+                          <string>CFBundleShortVersionString</string>
+                       </dict>
+                    </array>
 				</dict>
 			</dict>
 			<key>Processor</key>
@@ -122,6 +157,8 @@
 				<array>
 					<string>%RECIPE_CACHE_DIR%/unpack</string>
 					<string>%RECIPE_CACHE_DIR%/payload</string>
+					<string>%RECIPE_CACHE_DIR%/payload2</string>
+					<string>%RECIPE_CACHE_DIR%/payload3</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
This PR adds a dynamically added `minimum_os_version` key and populates the `installs` array.

Payload unpackaging part borrowed from the [pkg](https://github.com/autopkg/rtrouton-recipes/blob/master/CitrixWorkspace/CitrixWorkspace.pkg.recipe) recipe of Rich Trouton.