### PR TITLE
Update CitrixWorkspace.munki.recipe

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of Citrix Workspace and imports into Munki.</string>
+	<string>Downloads the current release version of Citrix Workspace and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.munki.CitrixWorkspace</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>NAME</key>
 		<string>CitrixWorkspace</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -41,7 +45,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.CitrixWorkspace</string>
 	<key>Process</key>
@@ -68,37 +72,39 @@
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>
 		</dict>
-        <dict>
-           <key>Arguments</key>
-           <dict>
-              <key>flat_pkg_path</key>
-              <string>%RECIPE_CACHE_DIR%/payload/Library/Application Support/CitrixPackage/com.citrix.apps.cwa.pkg</string>
-              <key>destination_path</key>
-              <string>%RECIPE_CACHE_DIR%/payload2</string>
-           </dict>
-           <key>Processor</key>
-           <string>FlatPkgUnpacker</string>
-        </dict>
-        <dict>
-           <key>Arguments</key>
-           <dict>
-              <key>pkg_payload_path</key>
-              <string>%RECIPE_CACHE_DIR%/payload2/com.citrix.ICAClientcwa.pkg/Payload</string>
-              <key>destination_path</key>
-              <string>%RECIPE_CACHE_DIR%/payload3</string>
-           </dict>
-           <key>Processor</key>
-           <string>PkgPayloadUnpacker</string>
-        </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>flat_pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Library/Application Support/CitrixPackage/com.citrix.apps.cwa.pkg</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload2</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload2/com.citrix.ICAClientcwa.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload3</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>faux_root</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<string>%RECIPE_CACHE_DIR%/payload3</string>
 				<key>installs_item_paths</key>
 				<array>
 					<string>/Applications/Citrix Workspace.app</string>
 				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>
@@ -108,61 +114,6 @@
 			<dict/>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload3/Applications/Citrix Workspace.app/Contents/Info.plist</string>
-				<key>plist_keys</key>
-				<dict>
-					<key>CFBundleShortVersionString</key>
-					<string>version</string>
-					<key>LSMinimumSystemVersion</key>
-					<string>minimum_os_version</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PlistReader</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-                    <key>minimum_os_version</key>
-                    <string>%minimum_os_version%</string>
-                    <key>installs</key>
-                    <array>
-                       <dict>
-                          <key>CFBundleShortVersionString</key>
-                          <string>%version%</string>
-                          <key>path</key>
-                          <string>/Applications/Citrix Workspace.app</string>
-                          <key>type</key>
-                          <string>application</string>
-                          <key>version_comparison_key</key>
-                          <string>CFBundleShortVersionString</string>
-                       </dict>
-                    </array>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/unpack</string>
-					<string>%RECIPE_CACHE_DIR%/payload</string>
-					<string>%RECIPE_CACHE_DIR%/payload2</string>
-					<string>%RECIPE_CACHE_DIR%/payload3</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
 		</dict>
 		<dict>
 			<key>Processor</key>
@@ -176,6 +127,20 @@
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+					<string>%RECIPE_CACHE_DIR%/payload2</string>
+					<string>%RECIPE_CACHE_DIR%/payload3/</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @hjuutilainen 

The latest changes to the CitrixWorkspace doesn't create a full installs array
```
<key>installs</key>
	<array>
		<dict>
			<key>CFBundleShortVersionString</key>
			<string>24.05.0</string>
			<key>path</key>
			<string>/Applications/Citrix Workspace.app</string>
			<key>type</key>
			<string>application</string>
			<key>version_comparison_key</key>
			<string>CFBundleShortVersionString</string>
		</dict>
	</array>
```

This PR 
- updates the munki recipe so that `MunkiInstallsItemsCreator` creates the Installs Array
- Adds in support for `derive_minimum_os_version` which needs a version bump to 2.7
- Removes unnecessary steps 
- entabs
- Moves path deleter to the end of the recipe

Installs Array after my changes
```
<key>installs</key>
	<array>
		<dict>
			<key>CFBundleIdentifier</key>
			<string>com.citrix.receiver.nomas</string>
			<key>CFBundleName</key>
			<string>Citrix Workspace</string>
			<key>CFBundleShortVersionString</key>
			<string>24.05.0</string>
			<key>CFBundleVersion</key>
			<string>700024.05.0.89</string>
			<key>minosversion</key>
			<string>12.0</string>
			<key>path</key>
			<string>/Applications/Citrix Workspace.app</string>
			<key>type</key>
			<string>application</string>
			<key>version_comparison_key</key>
			<string>CFBundleShortVersionString</string>
		</dict>
	</array>
```

Output from a successful verbose run
```
autopkg run -v CitrixWorkspace.munki.recipe
Looking for io.github.hjuutilainen.download.CitrixWorkspace...
Did not find io.github.hjuutilainen.download.CitrixWorkspace in recipe map
Rebuilding recipe map with current working directories...
Looking for io.github.hjuutilainen.download.CitrixWorkspace...
Found io.github.hjuutilainen.download.CitrixWorkspace in recipe map
**load_recipe time: 0.008076291996985674
Processing CitrixWorkspace.munki.recipe...
WARNING: CitrixWorkspace.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (DYNAMIC_URL): //downloads.citrix.com/22749/CitrixWorkspaceApp.dmg?__gda__=exp=1720795304~acl=/*~hmac=de60699453a42b5c40a20cfc68b878295015f45bf02d0771e816a5070991b8c9
URLTextSearcher: Found matching text (match): //downloads.citrix.com/22749/CitrixWorkspaceApp.dmg?__gda__=exp=1720795304~acl=/*~hmac=de60699453a42b5c40a20cfc68b878295015f45bf02d0771e816a5070991b8c9
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/downloads/CitrixWorkspace.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/downloads/CitrixWorkspace.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Citrix Workspace.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-07-08 12:14:10 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Citrix Systems, Inc. (S272Y5R93J)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            BC D0 33 AC EE 81 02 7D E3 52 C0 8D 0B D5 B9 A2 98 B8 CF DB B4 52 
CodeSignatureVerifier:            75 F4 51 67 01 04 11 17 4D AC
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/downloads/CitrixWorkspace.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.1wtnFh/Install Citrix Workspace.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/unpack/com.citrix.ICAClient.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload/Library/Application Support/CitrixPackage/com.citrix.apps.cwa.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload2
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload2/com.citrix.ICAClientcwa.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload3
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Citrix Workspace.app
MunkiInstallsItemsCreator: Derived minimum os version as: 12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.citrix.receiver.nomas', 'CFBundleName': 'Citrix Workspace', 'CFBundleShortVersionString': '24.05.0', 'CFBundleVersion': '700024.05.0.89', 'minosversion': '12.0', 'path': '/Applications/Citrix Workspace.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '12.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Citrix/CitrixWorkspace-24.05.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Citrix/CitrixWorkspace-24.05.0__1.dmg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/unpack
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload2
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/payload3/
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.CitrixWorkspace/receipts/CitrixWorkspace.munki-receipt-20240712-144154.plist

The following new items were imported into Munki:
    Name             Version  Catalogs  Pkginfo Path                                  Pkg Repo Path                               Icon Repo Path  
    ----             -------  --------  ------------                                  -------------                               --------------  
    CitrixWorkspace  24.05.0  testing   apps/Citrix/CitrixWorkspace-24.05.0__1.plist  apps/Citrix/CitrixWorkspace-24.05.0__1.dmg 
```
