### PR TITLE
Update GitUp.download

### DIFF
--- a/GitUp/GitUp.download.recipe
+++ b/GitUp/GitUp.download.recipe
@@ -60,7 +60,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/GitUp.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "co.gitup.mac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "88W3E55T4B")</string>
+				<string>anchor apple generic and identifier "co.gitup.mac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FP44AY6HHW)</string>
 				<key>strict_verification</key>
 				<true />
 			</dict>

--- a/GitUp/GitUp.download.recipe
+++ b/GitUp/GitUp.download.recipe
@@ -3,28 +3,32 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of GitUp. Set RELEASE_CHANNEL to "stable" or "continuous".</string>
+	<string>Downloads the latest version of GitUp.
+
+Set PRERELEASE to a non-empty string to download prereleases, either via Input in an override or via the -k option, i.e.: `-k PRERELEASE=yes`</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.GitUp</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>GitUp</string>
-		<key>RELEASE_CHANNEL</key>
-		<string>stable</string>
+		<key>PRERELEASE</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://s3-us-west-2.amazonaws.com/gitup-builds/%RELEASE_CHANNEL%/appcast.xml</string>
+				<key>asset_regex</key>
+				<string>.*\.zip$</string>
+				<key>github_repo</key>
+				<string>git-up/GitUp</string>
 			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Processor</key>
@@ -62,7 +66,7 @@
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "co.gitup.mac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FP44AY6HHW)</string>
 				<key>strict_verification</key>
-				<true />
+				<true/>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
Hi, @hjuutilainen 

This PR updates the Team ID in the code signature, and switches to using `GitHubReleasesInfoProvider` 

From the Developers release notes: https://github.com/git-up/GitUp/releases

> Rotate signed apple id certificates before the previous ones expire.
The download appcast now points to this git repo instead of Amazon S3.

Output from a successful -v run
```
autopkg run -v GitUp.munki.recipe
Looking for io.github.hjuutilainen.download.GitUp...
Did not find io.github.hjuutilainen.download.GitUp in recipe map
Rebuilding recipe map with current working directories...
Looking for io.github.hjuutilainen.download.GitUp...
Found io.github.hjuutilainen.download.GitUp in recipe map
**load_recipe time: 0.005494040990015492
Processing GitUp.munki.recipe...
WARNING: GitUp.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
WARNING: This is an unathenticated Github session, some API features may not work
GitHubReleasesInfoProvider: Matched regex '.*\.zip$' among asset(s): GitUp.zip
GitHubReleasesInfoProvider: Selected asset 'GitUp.zip' from tag 'v1.4.2' at url https://github.com/git-up/GitUp/releases/download/v1.4.2/GitUp.zip
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/downloads/GitUp-1.4.2.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename GitUp-1.4.2.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/downloads/GitUp-1.4.2.zip to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/GitUp
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/GitUp/GitUp.app: valid on disk
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/GitUp/GitUp.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/GitUp/GitUp.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/GitUp at /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/GitUp.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/GitUp/GitUp-1.4.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/GitUp/GitUp-1.4.2.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/io.github.hjuutilainen.munki.GitUp/receipts/GitUp.munki-receipt-20240812-134527.plist

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                  Pkg Repo Path               Icon Repo Path  
    ----   -------  --------  ------------                  -------------               --------------  
    GitUp  1.4.2    testing   apps/GitUp/GitUp-1.4.2.plist  apps/GitUp/GitUp-1.4.2.dmg
```