### PR TITLE
Update Obsidian.download.recipe to include newer builds

### DIFF
--- a/Obsidian/Obsidian.download.recipe
+++ b/Obsidian/Obsidian.download.recipe
@@ -23,7 +23,7 @@
 				<key>github_repo</key>
 				<string>obsidianmd/obsidian-releases</string>
 				<key>asset_regex</key>
-				<string>Obsidian-[0-9\.]+-universal\.dmg</string>
+				<string>Obsidian-[0-9\.]+\.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Seems like they dropped `-universal` for macOS builds, see their 1.6.7 release which wouldn't be captured by the old syntax.