### PR TITLE
Fix asset pattern for BorgBackup download

### DIFF
--- a/BorgBackup/BorgBackup.download.recipe
+++ b/BorgBackup/BorgBackup.download.recipe
@@ -25,7 +25,7 @@
 				<key>include_prereleases</key>
 				<false />
 				<key>asset_regex</key>
-				<string>^borg-macosx64$</string>
+				<string>^borg-macos.+\.tgz$</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Verbose recipe run output:

```
% autopkg run -vvq 'BorgBackup/BorgBackup.download.recipe'
Processing BorgBackup/BorgBackup.download.recipe...
WARNING: BorgBackup/BorgBackup.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^borg-macos.+\\.tgz$',
           'github_repo': 'borgbackup/borg',
           'include_prereleases': False}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '^borg-macos.+\.tgz$' among asset(s): 00_README.txt, borg-freebsd14, borg-freebsd14.asc, borg-freebsd14.tgz, borg-freebsd14.tgz.asc, borg-linux-glibc228, borg-linux-glibc228.asc, borg-linux-glibc228.tgz, borg-linux-glibc228.tgz.asc, borg-linux-glibc231, borg-linux-glibc231.asc, borg-linux-glibc231.tgz, borg-linux-glibc231.tgz.asc, borg-linux-glibc236, borg-linux-glibc236.asc, borg-linux-glibc236.tgz, borg-linux-glibc236.tgz.asc, borg-macos1012, borg-macos1012.asc, borg-macos1012.tgz, borg-macos1012.tgz.asc, borgbackup-1.4.0.tar.gz, borgbackup-1.4.0.tar.gz.asc
GitHubReleasesInfoProvider: Selected asset 'borg-macos1012.tgz' from release 'Release 1.4.0'
{'Output': {'asset_created_at': '2024-07-03T12:17:36Z',
            'asset_url': 'https://api.github.com/repos/borgbackup/borg/releases/assets/177441008',
            'release_notes': '## borgbackup 1.4.0\r\n'
                             '\r\n'
                             'First release for the new 1.4-maint branch.\r\n'
                             '\r\n'
                             'borg 1.4 is kind of a refreshed 1.2 with mostly '
                             'the same features and behavior, but a few bigger '
                             'changes that could introduce issues and thus '
                             'were not suitable for just releasing them as '
                             '1.2.x, but rather needed some testing first.\r\n'
                             '\r\n'
                             'Long changelog:\r\n'
                             ' \r\n'
                             'https://borgbackup.readthedocs.io/en/1.4.0/changes.html#version-1-4-0-2024-07-03\r\n'
                             '\r\n'
                             'Short borg 1.4 overview (from a borg 1.2 '
                             'perspective):\r\n'
                             '\r\n'
                             'https://www.borgbackup.org/releases/borg-1.4.html\r\n'
                             '\r\n'
                             '### Installation\r\n'
                             '\r\n'
                             'If you use pip to install this, use: pip install '
                             '"borgbackup==1.4.0"\r\n'
                             '\r\n'
                             'For other installation methods and more details, '
                             'please see: https://borgbackup.org/\r\n'
                             '\r\n'
                             'See also the 00_README.txt file in the assets '
                             'list below for a description of the available '
                             '"fat binary" downloads.\r\n',
            'url': 'https://github.com/borgbackup/borg/releases/download/1.4.0/borg-macos1012.tgz',
            'version': '1.4.0'}}
URLDownloader
{'Input': {'filename': 'borg',
           'url': 'https://github.com/borgbackup/borg/releases/download/1.4.0/borg-macos1012.tgz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 03 Jul 2024 12:17:41 GMT
URLDownloader: Storing new ETag header: "0x8DC9B5A22AE1BF5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.BorgBackup/downloads/borg
{'Output': {'download_changed': True,
            'etag': '"0x8DC9B5A22AE1BF5"',
            'last_modified': 'Wed, 03 Jul 2024 12:17:41 GMT',
            'pathname': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.BorgBackup/downloads/borg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.BorgBackup/downloads/borg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.BorgBackup/receipts/BorgBackup.download-receipt-20241224-193418.plist

The following new items were downloaded:
    Download Path                                                                                  
    -------------                                                                                  
    ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.BorgBackup/downloads/borg
```