### PR TITLE
Deprecate Citrix Receiver recipes

### DIFF
--- a/CitrixReceiver/CitrixReceiver.download.recipe
+++ b/CitrixReceiver/CitrixReceiver.download.recipe
@@ -12,7 +12,7 @@
 		<string>CitrixReceiver</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CitrixReceiver/CitrixReceiver.download.recipe
+++ b/CitrixReceiver/CitrixReceiver.download.recipe
@@ -17,6 +17,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Citrix Receiver was replaced by Citrix Workspace in August 2018 (details: https://www.citrix.com/downloads/citrix-receiver/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Citrix Receiver was replaced by Citrix Workspace in August 2018 (details: https://www.citrix.com/downloads/citrix-receiver/). This PR deprecates the Citrix Receiver recipes.