### PR TITLE
Update TeXstudio.download.recipe

### DIFF
--- a/TeXstudio/TeXstudio.download.recipe
+++ b/TeXstudio/TeXstudio.download.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%.zip</string>
 			</dict>
 		</dict>
 		<dict>

--- a/TeXstudio/TeXstudio.download.recipe
+++ b/TeXstudio/TeXstudio.download.recipe
@@ -23,7 +23,7 @@
 				<key>github_repo</key>
 				<string>texstudio-org/texstudio</string>
 				<key>asset_regex</key>
-				<string>texstudio-[0-9\.]+-osx\.dmg</string>
+				<string>texstudio-[0-9\.]+-osx\.zip</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Available download file is no longer a dmg. It was changed to a zip file.