### PR TITLE
Fix PkgUnpacker in CitrixWorkspace.munki.recipe

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -75,30 +75,8 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Library/Application Support/CitrixPackage/com.citrix.apps.cwa.pkg</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload2</string>
-			</dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload2/com.citrix.ICAClientcwa.pkg/Payload</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload3</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>faux_root</key>
-				<string>%RECIPE_CACHE_DIR%/payload3</string>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>installs_item_paths</key>
 				<array>
 					<string>/Applications/Citrix Workspace.app</string>
@@ -135,8 +113,6 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 				<array>
 					<string>%RECIPE_CACHE_DIR%/unpack</string>
 					<string>%RECIPE_CACHE_DIR%/payload</string>
-					<string>%RECIPE_CACHE_DIR%/payload2</string>
-					<string>%RECIPE_CACHE_DIR%/payload3/</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
Change of pkg structure:
-> pkg payload only has to be extracted once to get to the .app