### PR TITLE
Change permissions of Sourcetree.app during PkgRequest

### DIFF
--- a/Atlassian/SourceTree.pkg.recipe
+++ b/Atlassian/SourceTree.pkg.recipe
@@ -79,6 +79,8 @@
 							<string>root</string>
 							<key>group</key>
 							<string>admin</string>
+                                                        <key>mode</key>
+                                                        <string>0755</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Adds the mode => 0755 to the chown value of the pkg_request, to work around a change in permissions in the  issue in SourceTree download from Atlassian. 

Recently, Atlassian changed the permissions of the `Sourcetree.app` bundle the .zip download changed to `700`.  This works fine for standard drag-and-drop installations on a single-user system, but does not work for installations via an MDM or when multiple users share a system.

Credit for the source of the issue goes to the user Kornel at MacAdmins:
https://macadmins.slack.com/archives/C056155B4/p1750907055649409?thread_ts=1750842476.716239&cid=C056155B4