### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/ATLAS.ti/ATLAS.ti.pkg.recipe
+++ b/ATLAS.ti/ATLAS.ti.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/AlfredApp/Alfred2.pkg.recipe
+++ b/AlfredApp/Alfred2.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.runningwithcrayons.Alfred-2</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/AlfredApp/Alfred3.pkg.recipe
+++ b/AlfredApp/Alfred3.pkg.recipe
@@ -77,8 +77,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/AlfredApp/Alfred4.pkg.recipe
+++ b/AlfredApp/Alfred4.pkg.recipe
@@ -79,8 +79,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/AlfredApp/Alfred5.pkg.recipe
+++ b/AlfredApp/Alfred5.pkg.recipe
@@ -79,8 +79,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Atlassian/SourceTree.pkg.recipe
+++ b/Atlassian/SourceTree.pkg.recipe
@@ -68,8 +68,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.torusknot.SourceTreeNotMAS</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Axosoft/GitKraken.pkg.recipe
+++ b/Axosoft/GitKraken.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Blender/Blender.pkg.recipe
+++ b/Blender/Blender.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/BorgBackup/BorgBackup.pkg.recipe
+++ b/BorgBackup/BorgBackup.pkg.recipe
@@ -66,8 +66,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.borgcollective.borg</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Camunda/CamundaModeler.pkg.recipe
+++ b/Camunda/CamundaModeler.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/CheatSheet/CheatSheet.pkg.recipe
+++ b/CheatSheet/CheatSheet.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/CleverFiles/DiskDrill.pkg.recipe
+++ b/CleverFiles/DiskDrill.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/CodeRunner/CodeRunner2.pkg.recipe
+++ b/CodeRunner/CodeRunner2.pkg.recipe
@@ -75,8 +75,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/DaisyDisk/DaisyDisk.pkg.recipe
+++ b/DaisyDisk/DaisyDisk.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.daisydiskapp.DaisyDiskStandAlone</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/ELAN/ELAN.pkg.recipe
+++ b/ELAN/ELAN.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Elasticsearch/elasticbeat.pkg.recipe
+++ b/Elasticsearch/elasticbeat.pkg.recipe
@@ -77,8 +77,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>com.elasticsearch.%BEAT_NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Fork/Fork.pkg.recipe
+++ b/Fork/Fork.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/GIMP/Gimp.pkg.recipe
+++ b/GIMP/Gimp.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>org.gimp.gimp</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/GitUp/GitUp.pkg.recipe
+++ b/GitUp/GitUp.pkg.recipe
@@ -71,8 +71,6 @@
 				<dict>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Hannes Juutilainen/SUSInspector.pkg.recipe
+++ b/Hannes Juutilainen/SUSInspector.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/IINA/IINA.pkg.recipe
+++ b/IINA/IINA.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/JetBrains/AppCode.pkg.recipe
+++ b/JetBrains/AppCode.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>com.jetbrains.AppCode</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/JetBrains/PyCharmEdu.pkg.recipe
+++ b/JetBrains/PyCharmEdu.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Joplin/Joplin.pkg.recipe
+++ b/Joplin/Joplin.pkg.recipe
@@ -78,8 +78,6 @@ The architecture (ARCH) can be 'x86_64' or 'arm64'</string>
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Kaleidoscope/Kaleidoscope.pkg.recipe
+++ b/Kaleidoscope/Kaleidoscope.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.blackpixel.kaleidoscope</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>scripts</key>
 					<string>scripts</string>
 					<key>chown</key>

--- a/Kapeli/Dash3.pkg.recipe
+++ b/Kapeli/Dash3.pkg.recipe
@@ -75,8 +75,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/LibreOffice/LibreOffice.pkg.recipe
+++ b/LibreOffice/LibreOffice.pkg.recipe
@@ -71,8 +71,6 @@ LibreOffice Latest is the stable version with the most recent features. Users in
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>org.libreoffice.script</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Obsidian/Obsidian.pkg.recipe
+++ b/Obsidian/Obsidian.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/OpenOffice/OpenOffice.pkg.recipe
+++ b/OpenOffice/OpenOffice.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>org.openoffice.script.pkg</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Plex/PlexMediaServer.pkg.recipe
+++ b/Plex/PlexMediaServer.pkg.recipe
@@ -68,8 +68,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.plexapp.plexmediaserver</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Subler/Subler.pkg.recipe
+++ b/Subler/Subler.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>org.galad.Subler</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/TeXShop/TeXShop.pkg.recipe
+++ b/TeXShop/TeXShop.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>edu.uoregon.TeXShop</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/TeXstudio/TeXstudio.pkg.recipe
+++ b/TeXstudio/TeXstudio.pkg.recipe
@@ -95,8 +95,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>net.sourceforge.TeXstudio</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/TeamViewer/TeamViewerQuickSupport.pkg.recipe
+++ b/TeamViewer/TeamViewerQuickSupport.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>com.teamviewer.TeamViewerQS</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/ZipZapMac/Go2Shell.pkg.recipe
+++ b/ZipZapMac/Go2Shell.pkg.recipe
@@ -73,8 +73,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/iTerm2/iTerm2.pkg.recipe
+++ b/iTerm2/iTerm2.pkg.recipe
@@ -77,8 +77,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._