### PR TITLE
Adjust CitrixWorkspace Recipes

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.download.recipe
+++ b/CitrixReceiver/CitrixWorkspace.download.recipe
@@ -17,6 +17,24 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated. Please use com.github.rtrouton.download.citrixworkspace instead, which uses Citrix's official update catalog instead of web scraping.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>

--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -47,14 +47,14 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 	<key>MinimumVersion</key>
 	<string>2.7</string>
 	<key>ParentRecipe</key>
-	<string>io.github.hjuutilainen.download.CitrixWorkspace</string>
+	<string>com.github.rtrouton.download.citrixworkspace</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>flat_pkg_path</key>
-				<string>%pathname%/*.pkg</string>
+				<string>%pathname%</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 			</dict>


### PR DESCRIPTION
https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html now is behind a login. This moves the parent over to the rtrouton-recipes which is using Citrix's official XML update catalog as compared to web scraping. And then as it downloads the pkg directly now rather than a DMG and needing to get the pkg out of it, just a slight adjustment to the `flat_pkg_path`