### PR TITLE
restored Intel support for Blender recipes

### DIFF
--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Blender. (At least) Since v2.93 you may choose between x64 and arm64 as architecture. This recipes defaults to x64.</string>
+	<string>Downloads the latest Blender based on major version.
+
+Input options:
+
+- ARCHITECTURE: Either arm64 (default) for Apple Silicon, or x64 for Intel. Supported in v2.93 through current release, but x64 is not supported in major version 5 or later (see below).
+- MAJOR_VERSION: A major version number. Default should be the latest major version. For x64 downloads, use major version 4. This recipe supports major versions 2 through current release.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.Blender</string>
 	<key>Input</key>
@@ -12,6 +17,8 @@
 		<string>Blender</string>
 		<key>ARCHITECTURE</key>
 		<string>arm64</string>
+		<key>MAJOR_VERSION</key>
+		<string>5</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>
@@ -27,7 +34,7 @@
 				<key>url</key>
 				<string>https://download.blender.org/release/</string>
 				<key>re_pattern</key>
-				<string>(?s)(Blender(\d+\.\d+)/)(?!.*(Blender(\d+\.\d+)/))</string>
+				<string>(?s)(Blender(%MAJOR_VERSION%\.\d+)/)(?!.*(Blender(%MAJOR_VERSION%\.\d+)/))</string>
 			</dict>
 		</dict>
 		<dict>
@@ -51,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%ARCHITECTURE%.dmg</string>
 				<key>url</key>
 				<string>%URL_INTER%%match%</string>
 			</dict>

--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -8,7 +8,7 @@
 Input options:
 
 - ARCHITECTURE: Either arm64 (default) for Apple Silicon, or x64 for Intel. Supported in v2.93 through current release, but x64 is not supported in major version 5 or later (see below).
-- MAJOR_VERSION: A major version number. Default should be the latest major version. For x64 downloads, use major version 4. This recipe supports major versions 2 through current release.</string>
+- MAJOR_VERSION: A major version number (default should be the latest major version). This recipe supports major versions 2 through current release, but x64 downloads must use major version 4 or older.</string>
 	<key>Identifier</key>
 	<string>io.github.hjuutilainen.download.Blender</string>
 	<key>Input</key>

--- a/Blender/Blender.pkg.recipe
+++ b/Blender/Blender.pkg.recipe
@@ -68,7 +68,7 @@
 				<key>pkg_request</key>
 				<dict>
 					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
+					<string>%NAME%-%ARCHITECTURE%-%version%</string>
 					<key>version</key>
 					<string>%version%</string>
 					<key>id</key>


### PR DESCRIPTION
- Blender.download.recipe:
  - added %MAJOR_VERSION% input option
    - default is 5 (should be updated to latest as new major versions are released and tested)
    - supports major versions as old as 2
    - 4 is the latest supported by x64
  - updated Description to reflect correct default %ARCHITECTURE%, to describe acceptable values for %ARCHITECTURE% and %MAJOR_VERSION%, and to specifically call out the requirement of setting %MAJOR_VERSION% to 4 or older on x64 recipe overrides (closes #315)
  - first URLTextSearcher processor run now specifies %MAJOR_VERSION% in re_pattern
  - updated filename in URLDownloader to %NAME%-%ARCHITECTURE%.dmg
- Blender.pkg.recipe:
  - set pkgname to %NAME%-%ARCHITECTURE%-%version%