### PR TITLE
Libre Office release notes URL update

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -43,9 +43,9 @@ The architecture (ARCH) can be 'x86_64' or 'aarch64'
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>LibreOffice (?P&lt;version&gt;\d+\.\d+(\.\d+)?) \(\d{4}-\d{2}-\d{2}\) - %RELEASE% Release</string>
+				<string>LibreOffice (?P&lt;version&gt;\d+\.\d+(\.\d+)?) \(\w+ \d{2}, \d{4}\) - %RELEASE% Branch</string>
 				<key>url</key>
-				<string>https://www.libreoffice.org/download/release-notes/</string>
+				<string>https://www.libreoffice.org/release-notes/</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Hello there, 

The LibreOffice.download.recipe failed because the release-notes page was moved.
I changed the URL and adjusted the regex pattern of the `URLTextSearcher`. 

Kind regards
Mica


_autopkg run:_
```
autopkg run -vv io.github.hjuutilainen.download.LibreOffice
Processing io.github.hjuutilainen.download.LibreOffice...
WARNING: io.github.hjuutilainen.download.LibreOffice is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CreateLibreOfficeAuxArchName
{'Input': {'arch_name': 'x86_64'}}
{'Output': {'aux_arch_name': 'x86-64'}}
URLTextSearcher
{'Input': {'re_pattern': 'LibreOffice (?P<version>\\d+\\.\\d+(\\.\\d+)?) '
                         '\\(\\w+ \\d{2}, \\d{4}\\) - Latest Branch',
           'url': 'https://www.libreoffice.org/release-notes/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (version): 26.2.2
URLTextSearcher: Found matching text (match): 26.2.2
{'Output': {'match': '26.2.2', 'version': '26.2.2'}}
URLDownloader
{'Input': {'filename': 'LibreOffice-x86_64.dmg',
           'url': 'https://download.documentfoundation.org/libreoffice/stable/26.2.2/mac/x86_64/LibreOffice_26.2.2_MacOS_x86-64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 22 Mar 2026 21:53:12 GMT
URLDownloader: Storing new ETag header: "69c064c8-1230c613"
URLDownloader: Downloaded /Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg
{'Output': {'download_changed': True,
            'etag': '"69c064c8-1230c613"',
            'last_modified': 'Sun, 22 Mar 2026 21:53:12 GMT',
            'pathname': '/Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg/LibreOffice.app',
           'requirement': '(identifier "org.libreoffice.script.LibreOffice" or '
                          'identifier "org.libreoffice.script") and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7P5S3ZLCN7"',
           'strict_verification': True}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image /Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.9VHGib/LibreOffice.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9VHGib/LibreOffice.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9VHGib/LibreOffice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/receipts/io.github.hjuutilainen.download-receipt-20260413-103645.plist

The following new items were downloaded:
    Download Path                                                                                                   
    -------------                                                                                                   
    /Users/mica/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg  
```