### PR TITLE
fix: Use the sparkleurl for downloads

### DIFF
--- a/Atlassian/SourceTree.download.recipe
+++ b/Atlassian/SourceTree.download.recipe
@@ -17,15 +17,11 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://www.sourcetreeapp.com</string>
-				<key>re_pattern</key>
-				<string>"macURL":"(https://product-downloads.atlassian.com/software/sourcetree/ga/Source[Tt]ree_[0-9a-z\.]+_[0-9a-z\.]+\.zip)"</string>
-				<key>result_output_var_name</key>
-				<string>url</string>
+				<key>appcast_url</key>
+				<string>https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcast.xml</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Uses the sparkle url download endpoint vs the regex that seems to have changed again
```sh
autopkg run -vv ./Atlassian/SourceTree.download.recipe
Processing ./Atlassian/SourceTree.download.recipe...
WARNING: ./Atlassian/SourceTree.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcast.xml'}}
SparkleUpdateInfoProvider: Items in feed: 134
SparkleUpdateInfoProvider: Items in default channel: 134
SparkleUpdateInfoProvider: Version retrieved from appcast: 311
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.2.17
SparkleUpdateInfoProvider: Found URL https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_4.2.17_311.zip
{'Output': {'url': 'https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_4.2.17_311.zip',
            'version': '4.2.17'}}
URLDownloader
{'Input': {'url': 'https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_4.2.17_311.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 18 Feb 2026 06:17:19 GMT
URLDownloader: Storing new ETag header: "6251d029f17f2d7bc5637e09eb857aec-9"
URLDownloader: Downloaded /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/downloads/Sourcetree_4.2.17_311.zip
{'Output': {'download_changed': True,
            'etag': '"6251d029f17f2d7bc5637e09eb857aec-9"',
            'last_modified': 'Wed, 18 Feb 2026 06:17:19 GMT',
            'pathname': '/Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/downloads/Sourcetree_4.2.17_311.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/downloads/Sourcetree_4.2.17_311.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/downloads/Sourcetree_4.2.17_311.zip',
           'destination_path': '/Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/SourceTree',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Sourcetree_4.2.17_311.zip
Unarchiver: Unarchived /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/downloads/Sourcetree_4.2.17_311.zip to /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/SourceTree
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/SourceTree/SourceTree.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.torusknot.SourceTreeNotMAS" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = UPXU4CQZ5P)',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/SourceTree/SourceTree.app: valid on disk
CodeSignatureVerifier: /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/SourceTree/SourceTree.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/SourceTree/SourceTree.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/receipts/SourceTree.download-receipt-20260513-163648.plist

The following new items were downloaded:
    Download Path                                                                                                              
    -------------                                                                                                              
    /Users/zack_mccauley/Library/AutoPkg/Cache/io.github.hjuutilainen.download.SourceTree/downloads/Sourcetree_4.2.17_311.zip  
    ```