### PR TITLE
Fix ELAN glob path and code signature

### DIFF
--- a/ELAN/ELAN.download.recipe
+++ b/ELAN/ELAN.download.recipe
@@ -62,9 +62,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/ELAN*.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ELAN*/ELAN*.app</string>
 				<key>requirement</key>
-				<string>identifier "nl.mpi.elan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CUYD764JW9</string>
+				<string>identifier "nl.mpi.elan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = P7N398ZW7F</string>
 				<key>strict_verification</key>
 				<true />
 			</dict>

--- a/ELAN/ELAN.munki.recipe
+++ b/ELAN/ELAN.munki.recipe
@@ -52,7 +52,7 @@ With ELAN a user can add an unlimited number of textual annotations to audio and
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/ELAN*.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ELAN*/ELAN*.app</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/dmg_root/ELAN.app</string>
 				<key>overwrite</key>

--- a/ELAN/ELAN.pkg.recipe
+++ b/ELAN/ELAN.pkg.recipe
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/ELAN*.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ELAN*/ELAN*.app</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/Applications/ELAN.app</string>
 			</dict>


### PR DESCRIPTION
Fixes ELAN recipes that fail because the zip now extracts to a versioned subdirectory (e.g. `ELAN_7-1_mac/ELAN_7.1.app`) instead of placing the app at the top level. Also updates the code signing team identifier from `CUYD764JW9` to `P7N398ZW7F`.

Fixes #267.

<details><summary>Before:</summary>

```
% autopkg run -vv io.github.hjuutilainen.download.ELAN
WARNING: Did not load any default preferences.
WARNING: io.github.hjuutilainen.download.ELAN is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing io.github.hjuutilainen.download.ELAN...
URLTextSearcher
{'Input': {'re_pattern': '(https://www.mpi.nl/tools/elan/ELAN_[0-9\\-]+_?_mac\\.zip)',
           'result_output_var_name': 'url',
           'url': 'https://archive.mpi.nl/tla/elan/download'}}
URLTextSearcher: Found matching text (url): https://www.mpi.nl/tools/elan/ELAN_7-1_mac.zip
{'Output': {'url': 'https://www.mpi.nl/tools/elan/ELAN_7-1_mac.zip'}}
URLDownloader
{'Input': {'filename': 'ELAN.zip',
           'url': 'https://www.mpi.nl/tools/elan/ELAN_7-1_mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 08 Apr 2026 06:59:21 GMT
URLDownloader: Storing new ETag header: "5874997-64eed7073c9ab"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip
{'Output': {'download_changed': True,
            'etag': '"5874997-64eed7073c9ab"',
            'last_modified': 'Wed, 08 Apr 2026 06:59:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip',
           'destination_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename ELAN.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN*.app',
           'requirement': 'identifier "nl.mpi.elan" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = CUYD764JW9',
           'strict_verification': True}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/receipts/io.github.hjuutilainen.download-receipt-20260520-205925.plist

The following recipes failed:
    io.github.hjuutilainen.download.ELAN
        Error in io.github.hjuutilainen.download.ELAN: Processor: CodeSignatureVerifier: Error: Error processing path '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN*.app' with glob. 

The following new items were downloaded:
    Download Path                                                                                 
    -------------                                                                                 
    ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip
```

</details>

<details><summary>After:</summary>

```
% autopkg run -vv io.github.hjuutilainen.download.ELAN
WARNING: Did not load any default preferences.
WARNING: io.github.hjuutilainen.download.ELAN is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing io.github.hjuutilainen.download.ELAN...
URLTextSearcher
{'Input': {'re_pattern': '(https://www.mpi.nl/tools/elan/ELAN_[0-9\\-]+_?_mac\\.zip)',
           'result_output_var_name': 'url',
           'url': 'https://archive.mpi.nl/tla/elan/download'}}
URLTextSearcher: Found matching text (url): https://www.mpi.nl/tools/elan/ELAN_7-1_mac.zip
{'Output': {'url': 'https://www.mpi.nl/tools/elan/ELAN_7-1_mac.zip'}}
URLDownloader
{'Input': {'filename': 'ELAN.zip',
           'url': 'https://www.mpi.nl/tools/elan/ELAN_7-1_mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 08 Apr 2026 06:59:21 GMT
URLDownloader: Storing new ETag header: "5874997-64eed7073c9ab"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip
{'Output': {'download_changed': True,
            'etag': '"5874997-64eed7073c9ab"',
            'last_modified': 'Wed, 08 Apr 2026 06:59:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip',
           'destination_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename ELAN.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN*/ELAN*.app',
           'requirement': 'identifier "nl.mpi.elan" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = P7N398ZW7F',
           'strict_verification': True}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Using path '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN_7-1_mac/ELAN_7.1.app' matched from globbed '~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN*/ELAN*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN_7-1_mac/ELAN_7.1.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN_7-1_mac/ELAN_7.1.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/ELAN/ELAN_7-1_mac/ELAN_7.1.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/receipts/io.github.hjuutilainen.download-receipt-20260520-211713.plist

The following new items were downloaded:
    Download Path                                                                                 
    -------------                                                                                 
    ~/Library/AutoPkg/Cache/io.github.hjuutilainen.download.ELAN/downloads/ELAN.zip
```

</details>