### PR TITLE
1Password8.download: unpack payload from dynamic component pkg path

### DIFF
--- a/AgileBits/1Password8.download.recipe
+++ b/AgileBits/1Password8.download.recipe
@@ -58,11 +58,20 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>FileFinder</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/*.pkg/Payload</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/com.1Password.1Password.pkg/Payload</string>
+				<string>%found_filename%</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/Applications</string>
 			</dict>


### PR DESCRIPTION
Replace hardcoded component pkg payload path with FileFinder output. This handles upstream pkg layout/name changes (e.g. com.1Password.1Password.pkg -> 1Password-component.pkg)