### PR TITLE
Use APLooseVersion instead of distutils

### DIFF
--- a/HashiCorp/Vagrant.download.recipe
+++ b/HashiCorp/Vagrant.download.recipe
@@ -14,7 +14,7 @@
 		<string>Vagrant</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>2.0.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/HashiCorp/Vagrant.install.recipe
+++ b/HashiCorp/Vagrant.install.recipe
@@ -10,7 +10,7 @@
 	<dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>2.0.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Vagrant</string>
 	<key>Process</key>

--- a/HashiCorp/Vagrant.munki.recipe
+++ b/HashiCorp/Vagrant.munki.recipe
@@ -41,7 +41,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.0.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Vagrant</string>
 	<key>Process</key>

--- a/HashiCorp/Vault.download.recipe
+++ b/HashiCorp/Vault.download.recipe
@@ -14,7 +14,7 @@
 		<string>Vault</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>2.0.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SharedProcessors/HashiCorpURLProvider.py
+++ b/SharedProcessors/HashiCorpURLProvider.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 
 import json
 import re
-from distutils.version import LooseVersion
 
+from autopkglib import APLooseVersion as LooseVersion
 from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["HashiCorpURLProvider"]


### PR DESCRIPTION
AutoPkg has provided `APLooseVersion` since version 2.0.1 as a drop-in replacement for `distutils.version.LooseVersion`.

This PR updates your processor and any consuming recipes to leverage `APLooseVersion` for version comparison, which enables your recipe(s) to continue working with a future version of AutoPkg that includes a Python 3.12 or 3.13 runtime and drops `distutils`.

For the dotted numeric versions this processor handles, the resulting ordering is unchanged; `APLooseVersion` only differs from `distutils` on uncommon inputs such as zero-equivalent versions of differing length (e.g. `1.0` vs `1.0.0`).
