### PR TITLE
Ignore date to retrieve correct version

### DIFF
--- a/LibreOffice/LibreOffice.download.recipe
+++ b/LibreOffice/LibreOffice.download.recipe
@@ -43,7 +43,7 @@ The architecture (ARCH) can be 'x86_64' or 'aarch64'
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>LibreOffice (?P&lt;version&gt;\d+\.\d+(\.\d+)?) \(\w+ \d{2}, \d{4}\) - %RELEASE% Branch</string>
+				<string>LibreOffice (?P&lt;version&gt;\d+\.\d+(?:\.\d+)?) .*? - %RELEASE% Branch</string>
 				<key>url</key>
 				<string>https://www.libreoffice.org/release-notes/</string>
 			</dict>


### PR DESCRIPTION
Hi @hjuutilainen,

The date string on the release notes page does not have a preceding zero if the digit is a single one. This PR ignores the date string due to LibreOffice's ongoing unpredictable changes and focuses on the version string and the release branch.

Tested successfully with `Latest` and `x86_64` as well as `Previous` and `aarch64` (only first run shown:
```
   autopkg run -vvq LibreOffice/LibreOffice.download.recipe --ignore-parent-trust-verification-errors
Processing LibreOffice/LibreOffice.download.recipe...
WARNING: LibreOffice/LibreOffice.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CreateLibreOfficeAuxArchName
{'Input': {'arch_name': 'x86_64'}}
{'Output': {'aux_arch_name': 'x86-64'}}
URLTextSearcher
{'Input': {'re_pattern': 'LibreOffice (?P<version>\\d+\\.\\d+(?:\\.\\d+)?) .*? '
                         '- Latest Branch',
           'url': 'https://www.libreoffice.org/release-notes/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (version): 26.2.4
URLTextSearcher: Found matching text (match): 26.2.4
{'Output': {'match': '26.2.4', 'version': '26.2.4'}}
URLDownloader
{'Input': {'filename': 'LibreOffice-x86_64.dmg',
           'url': 'https://download.documentfoundation.org/libreoffice/stable/26.2.4/mac/x86_64/LibreOffice_26.2.4_MacOS_x86-64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 04 Jun 2026 06:42:23 GMT
URLDownloader: Storing new ETag header: "1236ad1f-65367d8bd5e80"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg
{'Output': {'download_changed': True,
            'etag': '"1236ad1f-65367d8bd5e80"',
            'last_modified': 'Thu, 04 Jun 2026 06:42:23 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg/LibreOffice.app',
           'requirement': '(identifier "org.libreoffice.script.LibreOffice" or '
                          'identifier "org.libreoffice.script") and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7P5S3ZLCN7"',
           'strict_verification': True}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image /Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.RFbNIQ/LibreOffice.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.RFbNIQ/LibreOffice.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.RFbNIQ/LibreOffice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/receipts/LibreOffice.download-receipt-20260608-104741.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ladmin/Library/AutoPkg/Cache/io.github.hjuutilainen.download.LibreOffice/downloads/LibreOffice-x86_64.dmg
```