### PR TITLE
Update CitrixWorkspace.munki.recipe

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -54,7 +54,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 			<key>Arguments</key>
 			<dict>
 				<key>flat_pkg_path</key>
-				<string>%pathname%</string>
+				<string>%pathname%/*.pkg</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 			</dict>


### PR DESCRIPTION
Return to globbing for a pkg for the flat_pkg_path variable for FlatPkgUnpacker processor since, as of today, the parent download fetches a DMG and not a PKG.