### PR TITLE
Point FlatPkgUnpacker at pkg inside dmg

### DIFF
--- a/CitrixReceiver/CitrixWorkspace.munki.recipe
+++ b/CitrixReceiver/CitrixWorkspace.munki.recipe
@@ -54,7 +54,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 			<key>Arguments</key>
 			<dict>
 				<key>flat_pkg_path</key>
-				<string>%pathname%</string>
+				<string>%pathname%/Install Citrix Workspace.pkg</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 			</dict>


### PR DESCRIPTION
Parent recipe now downloads a dmg instead of a bare flat pkg, so flat_pkg_path must reach into the mounted dmg to find the installer pkg.