### PR TITLE
CodeSignatureVerifier strict_verification causes latest version to fail

### DIFF
--- a/ATLAS.ti/ATLAS.ti.download.recipe
+++ b/ATLAS.ti/ATLAS.ti.download.recipe
@@ -44,7 +44,7 @@
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.atlasti.ATLAS-ti" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5B3ZVQ9HJ3")</string>
 				<key>strict_verification</key>
-				<true />
+				<false />
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
The CodeSignatureVerifier processor fails with error "resource fork, Finder information, or similar detritus not allowed" on version 26.1.1.  Does strict_verification need to be enabled?